### PR TITLE
[patch:lib] Removed metric option in evaluate() + add more validations

### DIFF
--- a/examples/Input Format.ipynb
+++ b/examples/Input Format.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Pen-Tip Trajectories (Example).ipynb
+++ b/examples/Pen-Tip Trajectories (Example).ipynb
@@ -80,14 +80,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Labels: ('a', 'b', 'c', 'd', 'e', 'g', 'h', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 'u', 'v', 'w', 'y', 'z')\n",
+      "Labels: ['a', 'b', 'c', 'd', 'e', 'g', 'h', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 'u', 'v', 'w', 'y', 'z']\n",
       "Number of labels: 20\n"
      ]
     }
    ],
    "source": [
     "# Retrieve the set of unique labels and report the number of labels\n",
-    "labels = tuple(label[0] for label in data['consts'][0][0][3][0])\n",
+    "labels = [label[0] for label in data['consts'][0][0][3][0]]\n",
     "n_labels = len(labels)\n",
     "print('Labels: {}'.format(str(labels)))\n",
     "print('Number of labels: {}'.format(n_labels))"
@@ -251,7 +251,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Dynamic Time Warping $k$-NN"
+    "## Dynamic Time Warping $k$-NN\n",
+    "\n",
+    "TODO\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Importing, creating and fitting the classifier:"
    ]
   },
   {
@@ -277,6 +283,34 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Calculating distances: 100%|██████████| 2286/2286 [00:12<00:00, 177.94it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'d'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Predict the first test example\n",
+    "clf.predict(X_test[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
    "outputs": [
@@ -284,57 +318,35 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating distances: 100%|██████████| 2286/2286 [00:12<00:00, 184.14it/s]\n",
-      "Classifying examples:   0%|          | 0/5 [00:00<?, ?it/s]"
+      "Classifying examples: 100%|██████████| 5/5 [00:47<00:00,  9.46s/it]\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "d\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Classifying examples: 100%|██████████| 5/5 [00:50<00:00, 10.18s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['d', 'r', 'c', 'l', 's']\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
+     "data": {
+      "text/plain": [
+       "['d', 'r', 'c', 'l', 's']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Predict the first test example\n",
-    "print('Prediction for first example: {}'.format(clf.predict(X_test[0])))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Predict the first 5 test examples\n",
-    "print('Predictions for first 5 examples: {}'.format(clf.predict(X_test[:5])))"
+    "clf.predict(X_test[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -343,25 +355,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Classifying examples: 100%|██████████| 3/3 [00:31<00:00, 10.55s/it]\n"
-     ]
-    },
-    {
-     "ename": "NameError",
-     "evalue": "name 'confusion_matrix' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-11-d3870d5706ea>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0macc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcm\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mevaluate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX_test\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my_test\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0macc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Development/Python/sequentia/lib/sequentia/classifiers/dtwknn/dtwknn.py\u001b[0m in \u001b[0;36mevaluate\u001b[0;34m(self, X, y, metric, labels, verbose)\u001b[0m\n\u001b[1;32m    129\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    130\u001b[0m         \u001b[0;31m# Calculate confusion matrix and precision and recall\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 131\u001b[0;31m         \u001b[0mcm\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mconfusion_matrix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpredictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mlabels\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    132\u001b[0m         \u001b[0mprecision\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmean\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdiag\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcm\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcm\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    133\u001b[0m         \u001b[0mrecall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmean\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdiag\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcm\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcm\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'confusion_matrix' is not defined"
+      "Classifying examples: 100%|██████████| 3/3 [00:28<00:00,  9.62s/it]\n"
      ]
     }
    ],
    "source": [
-    "acc, cm = clf.evaluate(X_test[:3], y_test[:3])\n",
-    "acc"
+    "acc, cm = clf.evaluate(X_test[:3], y_test[:3], labels=labels)"
    ]
   },
   {
@@ -373,12 +372,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training HMM for label 'a'...\n",
+      "Training HMM for label 'b'...\n",
+      "Training HMM for label 'c'...\n",
+      "Training HMM for label 'd'...\n",
+      "Training HMM for label 'e'...\n",
+      "Training HMM for label 'g'...\n",
+      "Training HMM for label 'h'...\n",
+      "Training HMM for label 'l'...\n",
+      "Training HMM for label 'm'...\n",
+      "Training HMM for label 'n'...\n",
+      "Training HMM for label 'o'...\n",
+      "Training HMM for label 'p'...\n",
+      "Training HMM for label 'q'...\n",
+      "Training HMM for label 'r'...\n",
+      "Training HMM for label 's'...\n",
+      "Training HMM for label 'u'...\n",
+      "Training HMM for label 'v'...\n",
+      "Training HMM for label 'w'...\n",
+      "Training HMM for label 'y'...\n",
+      "Training HMM for label 'z'...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sequentia.classifiers import HMM, HMMClassifier\n",
+    "\n",
+    "hmms = []\n",
+    "for label in labels:\n",
+    "    print(\"Training HMM for label '{}'...\".format(label))\n",
+    "    hmm = HMM(label=label, n_states=10, topology='left-right')\n",
+    "    hmm.set_random_initial()\n",
+    "    hmm.set_random_transitions()\n",
+    "    hmm.fit([X_train[i] for i, y_i in enumerate(y_train) if y_i == label])\n",
+    "    hmms.append(hmm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sequentia.classifiers import HMM, HMMClassifier"
+    "clf = HMMClassifier()\n",
+    "clf.fit(hmms)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc, cm = clf.evaluate(X_test[:50], y_test[:50], labels=labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Preprocessing.ipynb
+++ b/examples/Preprocessing.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/lib/sequentia/classifiers/dtwknn/dtwknn.py
+++ b/lib/sequentia/classifiers/dtwknn/dtwknn.py
@@ -103,37 +103,27 @@ class DTWKNN:
 
             return labels
 
-    def evaluate(self, X: List[np.ndarray], y: List[str], metric='accuracy', labels=None, verbose=True) -> Tuple[float, np.ndarray]:
+    def evaluate(self, X: List[np.ndarray], y: List[str], labels=None, verbose=True) -> Tuple[float, np.ndarray]:
         """Evaluates the performance of the classifier on a batch of observation sequences and their labels.
 
         Parameters:
             X {list(numpy.ndarray)} - A list of multiple observation sequences.
             y {list(str)} - A list of labels for the observation sequences.
-            metric {str} - A performance metric for the classification - one of
-                'accuracy' (categorical accuracy) or 'f1' (F1 score = harmonic mean of precision and recall).
             labels {list(str)} - A list of labels for ordering the axes of the confusion matrix.
             verbose {bool} - Whether to display a progress bar for predictions or not.
 
         Return: {tuple(float, numpy.ndarray)}
-            - The specified performance result: either categorical accuracy or F1 score.
+            - The categorical accuracy of the classifier on the observation sequences.
             - A confusion matrix representing the discrepancy between predicted and actual labels.
         """
         self._val.observation_sequences_and_labels(X, y)
-        self._val.one_of(metric, ['accuracy', 'f1'], desc='metric')
         self._val.boolean(verbose, desc='verbose')
 
         if labels is not None:
             self._val.list_of_strings(labels, desc='confusion matrix labels')
 
-        # Classify each observation sequence
+        # Classify each observation sequence and calculate confusion matrix
         predictions = self.predict(X)
-
-        # Calculate confusion matrix and precision and recall
         cm = confusion_matrix(y, predictions, labels=labels)
-        precision = np.mean(np.diag(cm) / np.sum(cm, axis=0))
-        recall = np.mean(np.diag(cm) / np.sum(cm, axis=1))
 
-        if metric == 'accuracy':
-            return np.sum(np.diag(cm)) / len(predictions), cm
-        elif metric == 'f1':
-            return 2.0 * precision * recall / (precision + recall), cm
+        return np.sum(np.diag(cm)) / np.sum(cm), cm

--- a/lib/sequentia/classifiers/hmm/hmm.py
+++ b/lib/sequentia/classifiers/hmm/hmm.py
@@ -117,6 +117,12 @@ class HMM:
                 where T may vary per observation sequence.
         """
         self._val.observation_sequences(X)
+
+        try:
+            (self._initial, self._transitions)
+        except AttributeError as e:
+            raise AttributeError('Must specify initial state distribution and transitions before the HMM can be fitted') from e
+
         self._n_seqs = len(X)
         self._n_features = X[0].shape[1]
 

--- a/lib/sequentia/classifiers/hmm/hmm_classifier.py
+++ b/lib/sequentia/classifiers/hmm/hmm_classifier.py
@@ -42,14 +42,18 @@ class HMMClassifier:
         if isinstance(models, list):
             if not all(isinstance(model, HMM) for model in models):
                 raise TypeError('Expected all models to be HMM objects')
-            self._models = models
         elif isinstance(models, dict):
             values = list(models.values())
             if not all(isinstance(model, HMM) for model in values):
                 raise TypeError('Expected all models to be HMM objects')
-            self._models = values
+            models = values
         else:
             raise TypeError('Expected models to be a list or dict of HMM objects')
+
+        if len(models) > 0:
+            self._models = models
+        else:
+            raise RuntimeError('Must fit the classifier with at least one HMM')
 
     def predict(self, X: Union[np.ndarray, List[np.ndarray]], prior=True, return_scores=False) -> Union[str, List[str]]:
         """Predicts the label for an observation sequence (or multiple sequences) according to maximum likelihood or posterior scores.
@@ -68,6 +72,11 @@ class HMMClassifier:
         self._val.boolean(return_scores, desc='return_scores')
         self._val.observation_sequences(X, allow_single=True)
 
+        try:
+            self._models
+        except AttributeError as e:
+            raise AttributeError('The classifier needs to be fitted before predictions are made') from e
+
         total_seqs = sum(model.n_seqs for model in self._models)
 
         if isinstance(X, np.ndarray): # Single observation sequence
@@ -82,7 +91,7 @@ class HMMClassifier:
                 predictions.append((best[0], scores) if return_scores else best[0])
             return predictions
 
-    def evaluate(self, X: List[np.ndarray], y: List[str], prior=True, metric='accuracy', labels=None) -> Tuple[float, np.ndarray]:
+    def evaluate(self, X: List[np.ndarray], y: List[str], prior=True, labels=None) -> Tuple[float, np.ndarray]:
         """Evaluates the performance of the classifier on a batch of observation sequences and their labels.
 
         Parameters:
@@ -90,30 +99,20 @@ class HMMClassifier:
             y {list(str)} - A list of labels for the observation sequences.
             prior {bool} - Whether to calculate a prior and perform MAP estimation. If this parameter is set
                 to False, then the negative log likelihoods generated from the models' `forward` function are used.
-            metric {str} - A performance metric for the classification - one of
-                'accuracy' (categorical accuracy) or 'f1' (F1 score = harmonic mean of precision and recall).
             labels {list(str)} - A list of labels for ordering the axes of the confusion matrix.
 
         Return: {tuple(float, numpy.ndarray)}
-            - The specified performance result: either categorical accuracy or F1 score.
+            - The categorical accuracy of the classifier on the observation sequences.
             - A confusion matrix representing the discrepancy between predicted and actual labels.
         """
         self._val.observation_sequences_and_labels(X, y)
         self._val.boolean(prior, desc='prior')
-        self._val.one_of(metric, ['accuracy', 'f1'], desc='evaluation metric')
 
         if labels is not None:
             self._val.list_of_strings(labels, desc='confusion matrix labels')
 
-        # Classify each observation sequence
+        # Classify each observation sequence and calculate confusion matrix
         predictions = self.predict(X, prior, return_scores=False)
-
-        # Calculate confusion matrix and precision and recall
         cm = confusion_matrix(y, predictions, labels=labels)
-        precision = np.mean(np.diag(cm) / np.sum(cm, axis=0))
-        recall = np.mean(np.diag(cm) / np.sum(cm, axis=1))
 
-        if metric == 'accuracy':
-            return np.sum(np.diag(cm)) / len(predictions), cm
-        elif metric == 'f1':
-            return 2.0 * precision * recall / (precision + recall), cm
+        return np.sum(np.diag(cm)) / np.sum(cm), cm


### PR DESCRIPTION
- As precision and recall measures can raise zero division errors, the option of calculating an F1 score was removed from classifier `evaluate` functions–since the user can still do this with the returned confusion matrix.