### PR TITLE
[add:lib] Add 'n_jobs' parameter to HMM fit()

### DIFF
--- a/examples/Pen-Tip Trajectories (Example).ipynb
+++ b/examples/Pen-Tip Trajectories (Example).ipynb
@@ -432,7 +432,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Ensemble Hidden Markov Models"
+    "## Ensemble Hidden Markov Models\n",
+    "\n",
+    "TODO\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Creating the individual HMMs and fitting each one on the training examples corresponding to the label (character) that it represents.\n",
+    "\n",
+    "**Note**: Here we naively set the number of states for all HMMs to 10. In reality, you will probably want to have different numbers of states for HMMs that represent more complex or more simple classes (characters in this case)."
    ]
   },
   {
@@ -498,6 +506,13 @@
    "source": [
     "acc, cm = clf.evaluate(X_test, y_test, labels=labels)\n",
     "show_results(acc, cm, dataset='test')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As explained earlier, some HMMs might require a higher or lower number of states depending on how complex or simple the representing class is. In this case, the HMM representing the `w` trajectory should possibly have more states, as `w` is generally a more 'complex' character to draw compared to others."
    ]
   }
  ],

--- a/lib/sequentia/classifiers/hmm/hmm.py
+++ b/lib/sequentia/classifiers/hmm/hmm.py
@@ -109,14 +109,16 @@ class HMM:
     def set_random_transitions(self):
         self._transitions = self._topology.random_transitions()
 
-    def fit(self, X: List[np.ndarray]):
+    def fit(self, X: List[np.ndarray], n_jobs=1: int):
         """Fits the HMM to observation sequences assumed to be labeled as the class that the model represents.
 
         Parameters:
             X {list(numpy.ndarray)} - Collection of multivariate observation sequences, each of shape (T, D)
                 where T may vary per observation sequence.
+            n_jobs {int} - The number of threads to use when performing training.
         """
         self._val.observation_sequences(X)
+        self._val.integer(n_jobs, 'number of jobs')
 
         try:
             (self._initial, self._transitions)
@@ -138,7 +140,7 @@ class HMM:
         )
 
         # Perform the Baum-Welch algorithm to fit the model to the observations
-        self._model.fit(X)
+        self._model.fit(X, n_jobs=n_jobs)
 
         # Update the initial state distribution and transitions to reflect the updated parameters
         inner_tx = self._model.dense_transition_matrix()[:, :self._n_states]


### PR DESCRIPTION
- Add parallelism support through the `n_jobs` parameter in the `fit()` function for the `HMM` class.