### PR TITLE
[patch:docs] Use explicit HTML anchors for nbviewer URLs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+notebooks/* linguist-documentation

--- a/notebooks/Pen-Tip Trajectories (Example).ipynb
+++ b/notebooks/Pen-Tip Trajectories (Example).ipynb
@@ -43,7 +43,7 @@
     "\n",
     "---\n",
     "\n",
-    "First, we will download the dataset and extract the samples and labels, then convert them so that they are in a format compatible with Sequentia (see the [_Input Format_](https://nbviewer.jupyter.org/github/eonu/sequentia/blob/master/notebooks/1%20-%20Input%20Format%20%28Tutorial%29.ipynb) notebook for more information): "
+    "First, we will download the dataset and extract the samples and labels, then convert them so that they are in a format compatible with Sequentia (see the <a href=\"https://nbviewer.jupyter.org/github/eonu/sequentia/blob/master/notebooks/1%20-%20Input%20Format%20%28Tutorial%29.ipynb\"><em>Input Format</em></a> notebook for more information): "
    ]
   },
   {
@@ -163,7 +163,7 @@
     "- Using a faster, restricted distance measure that can handle sequences of different length (see [FastDTW](https://pdfs.semanticscholar.org/05a2/0cde15e172fc82f32774dd0cf4fe5827cad2.pdf))\n",
     "- Parallelization (only supported in the `DTWKNN` class)\n",
     "\n",
-    "The `DTWKNN` class always uses the FastDTW algorithm to calculate distances. Downsampling is offered as one of the preprocessing methods in Sequentia, and is used as follows (see the [_Preprocessing_](https://nbviewer.jupyter.org/github/eonu/sequentia/blob/master/notebooks/2%20-%20Preprocessing%20%28Tutorial%29.ipynb) notebook for more information):"
+    "The `DTWKNN` class always uses the FastDTW algorithm to calculate distances. Downsampling is offered as one of the preprocessing methods in Sequentia, and is used as follows (see the <a href=\"https://nbviewer.jupyter.org/github/eonu/sequentia/blob/master/notebooks/2%20-%20Preprocessing%20%28Tutorial%29.ipynb\"><em>Preprocessing</em></a> notebook for more information):"
    ]
   },
   {


### PR DESCRIPTION
- Add `.gitattributes` and hide Jupyter notebooks from repository language classification.
- Use explicit HTML anchors for nbviewer URLs in notebooks.