### PR TITLE
[patch:lib] Re-add 'euclidean' metric as DTWKNN default

### DIFF
--- a/lib/sequentia/classifiers/dtwknn/dtwknn.py
+++ b/lib/sequentia/classifiers/dtwknn/dtwknn.py
@@ -27,7 +27,7 @@ class DTWKNN:
         Distance metric for FastDTW.
     """
 
-    def __init__(self, k, radius, metric: euclidean):
+    def __init__(self, k, radius, metric=euclidean):
         self._val = Validator()
         self._k = self._val.restricted_integer(
             k, lambda x: x > 0, desc='number of neighbors', expected='greater than zero')


### PR DESCRIPTION
- Re-add `euclidean` metric as `DTWKNN` default.