### PR TITLE
[patch:docs] Add explicit labels to HMMClassifier example

### DIFF
--- a/docs/_includes/examples/classifiers/hmm_classifier.py
+++ b/docs/_includes/examples/classifiers/hmm_classifier.py
@@ -1,10 +1,13 @@
 import numpy as np
 from sequentia.classifiers import HMM, HMMClassifier
 
+# Set of possible labels
+labels = [f'class{i}' for i in range(5)]
+
 # Create and fit some sample HMMs
 hmms = []
-for i in range(5):
-    hmm = HMM(label=f'class{i}', n_states=(i + 3), topology='left-right')
+for i, label in enumerate(labels):
+    hmm = HMM(label=label, n_states=(i + 3), topology='left-right')
     hmm.set_random_initial()
     hmm.set_random_transitions()
     hmm.fit([np.arange((i + j * 20) * 30).reshape(-1, 3) for j in range(1, 4)])
@@ -18,4 +21,4 @@ y = ['class0', 'class1', 'class1']
 clf = HMMClassifier()
 clf.fit(hmms)
 predictions = clf.predict(X)
-accuracy, confusion = clf.evaluate(X, y)
+accuracy, confusion = clf.evaluate(X, y, labels=labels)


### PR DESCRIPTION
- Add explicit labels to `evaluate()` in `HMMClassifier` example.