### PR TITLE
[release] 0.4.0 🎉 (🛠)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.4.0](https://github.com/eonu/sequentia/releases/tag/v0.4.0)
+
+#### Major changes
+
+- Re-add `euclidean` metric as `DTWKNN` default. ([#43](https://github.com/eonu/sequentia/pull/43))
+
+#### Minor changes
+
+- Add explicit labels to `evaluate()` in `HMMClassifier` example. ([#44](https://github.com/eonu/sequentia/pull/44))
+
 ## [0.3.0](https://github.com/eonu/sequentia/releases/tag/v0.3.0)
 
 #### Major changes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2020, Edwin Onuonga'
 author = 'Edwin Onuonga'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.0'
+release = '0.4.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 from setuptools import setup, find_packages
 
-VERSION = '0.3.0'
+VERSION = '0.4.0'
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()


### PR DESCRIPTION
# Major changes

- Re-add `euclidean` metric as `DTWKNN` default. ([#43](https://github.com/eonu/sequentia/pull/43))

# Minor changes

- Add explicit labels to `evaluate()` in `HMMClassifier` example. ([#44](https://github.com/eonu/sequentia/pull/44))