### PR TITLE
[rm:lib] Don't refer to HMM classifier as ensemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Sequentia offers the use of **multivariate observation sequences with differing 
 
 ### Classication algorithms
 
-- [x] Ensemble Hidden Markov Models (via [Pomegranate](https://github.com/jmschrei/pomegranate) [[1]](#references))
+- [x] Hidden Markov Models (via [Pomegranate](https://github.com/jmschrei/pomegranate) [[1]](#references))
   - [x] Multivariate Gaussian Emissions
   - [ ] Gaussian Mixture Model Emissions (_soon!_)
   - [x] Left-Right and Ergodic Topologies

--- a/docs/sections/classifiers/hmm.rst
+++ b/docs/sections/classifiers/hmm.rst
@@ -104,7 +104,7 @@ To classify a new observation sequence :math:`O'`, this works by:
 These steps are summarized in the diagram below.
 
 .. image:: https://i.ibb.co/gPymgs4/classifier.png
-    :alt: Ensemble HMM Classifier System
+    :alt: HMM Classifier
     :width: 400
 
 Example

--- a/docs/sections/classifiers/hmm.rst
+++ b/docs/sections/classifiers/hmm.rst
@@ -65,7 +65,7 @@ A score for how likely a HMM is to generate an observation sequence is given by 
 :math:`\mathbb{P}(O|\lambda_c)` of the HMM :math:`\lambda_c` generating the observation sequence :math:`O`.
 
 **Note**: The likelihood does not account for the fact that a particular observation class
-may occur more or less frequently than other observation classes. Once an ensemble of :class:`~HMM` objects
+may occur more or less frequently than other observation classes. Once a group of :class:`~HMM` objects
 (represented by a :class:`~HMMClassifier`) is created and configured, this can be accounted for by
 calculating the joint probability (or un-normalized posterior)
 :math:`\mathbb{P}(O, \lambda_c)=\mathbb{P}(O|\lambda_c)\mathbb{P}(\lambda_c)`
@@ -88,10 +88,10 @@ API reference
 .. autoclass:: sequentia.classifiers.hmm.HMM
     :members:
 
-Ensemble Hidden Markov Model Classifier (``HMMClassifier``)
-===========================================================
+Hidden Markov Model Classifier (``HMMClassifier``)
+==================================================
 
-Multiple HMMs can be combined to form an ensemble multi-class classifier.
+Multiple HMMs can be combined to form a multi-class classifier.
 To classify a new observation sequence :math:`O'`, this works by:
 
 1. | Creating and training the HMMs :math:`\lambda_1, \lambda_2, \ldots, \lambda_N`.

--- a/lib/sequentia/classifiers/hmm/hmm_classifier.py
+++ b/lib/sequentia/classifiers/hmm/hmm_classifier.py
@@ -4,13 +4,13 @@ from sklearn.metrics import confusion_matrix
 from ...internals import _Validator
 
 class HMMClassifier:
-    """An ensemble classifier that combines individual :class:`~HMM` objects, which model isolated sequences from different classes."""
+    """A classifier that combines individual :class:`~HMM` objects, which model isolated sequences from different classes."""
 
     def __init__(self):
         self._val = _Validator()
 
     def fit(self, models):
-        """Fits the ensemble classifier with a collection of :class:`~HMM` objects.
+        """Fits the classifier with a collection of :class:`~HMM` objects.
 
         Parameters
         ----------

--- a/notebooks/1 - Input Format (Tutorial).ipynb
+++ b/notebooks/1 - Input Format (Tutorial).ipynb
@@ -129,7 +129,7 @@
     "\n",
     "---\n",
     "\n",
-    "This is as a direct consequence of the [`pomegranate.hmm.HiddenMarkovModel`](https://pomegranate.readthedocs.io/en/latest/HiddenMarkovModel.html#pomegranate.hmm.HiddenMarkovModel) class requiring a string to be passed as the `name` parameter in the constructor. In the case of ensemble HMMs, each HMM represents a single class, and therefore we set the `name` of each HMM to be the label of the class it represents.\n",
+    "This is as a direct consequence of the [`pomegranate.hmm.HiddenMarkovModel`](https://pomegranate.readthedocs.io/en/latest/HiddenMarkovModel.html#pomegranate.hmm.HiddenMarkovModel) class requiring a string to be passed as the `name` parameter in the constructor. In the case of a HMM classifier, each HMM represents a single class, and therefore we set the `name` of each HMM to be the label of the class it represents.\n",
     "\n",
     "The implementation of $k$-NN in Sequentia can easily be modified internally to handle labels of arbitrary type – but to keep consistent with the above restriction on `HMM`s requiring string labels, the `DTWKNN` class also requires labels to be strings.\n",
     "\n",

--- a/notebooks/Pen-Tip Trajectories (Example).ipynb
+++ b/notebooks/Pen-Tip Trajectories (Example).ipynb
@@ -44,7 +44,7 @@
     "---\n",
     "\n",
     "- [Dynamic Time Warping $k$-NN](#Dynamic-Time-Warping-%24k%24-NN)\n",
-    "- [Ensemble Hidden Markov Models](#Ensemble-Hidden-Markov-Models)"
+    "- [Hidden Markov Models](#Hidden-Markov-Models)"
    ]
   },
   {

--- a/notebooks/Pen-Tip Trajectories (Example).ipynb
+++ b/notebooks/Pen-Tip Trajectories (Example).ipynb
@@ -582,9 +582,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Ensemble Hidden Markov Models\n",
+    "## Hidden Markov Models\n",
     "\n",
-    "An ensemble of HMMs can be a good classifier for isolated sequences. The main idea behind using ensemble HMMs for classification is as follows:\n",
+    "A group of HMMs can be a good classifier for isolated sequences. The main idea behind using HMMs for classification is as follows:\n",
     "\n",
     "1. Create $N$ HMMs $\\lambda_1,\\lambda_2,\\ldots,\\lambda_N$, each representing a different class (character in this case).\n",
     "2. Fit each of these HMMs only using the training examples labeled with the class that the HMM represents. _The Baum-Welch algorithm is used for training here_.\n",
@@ -647,7 +647,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `HMMClassifier` object collects each of the individual `HMM` objects in order to create the ensemble classifier:"
+    "A `HMMClassifier` object collects each of the individual `HMM` objects in order to create the classifier:"
    ]
   },
   {


### PR DESCRIPTION
- As the HMM classifier is not a true ensemble of HMMs (since each HMM doesn't really contribute to the classification), it is no longer referred to as an ensemble.