### PR TITLE
[patch:lib] Remove strict 2D np.ndarray (use np.atleast_2d)

### DIFF
--- a/lib/sequentia/classifiers/dtwknn/dtwknn.py
+++ b/lib/sequentia/classifiers/dtwknn/dtwknn.py
@@ -73,7 +73,7 @@ class DTWKNN:
         except AttributeError:
             raise RuntimeError('The classifier needs to be fitted before predictions are made')
 
-        self._val.observation_sequences(X, allow_single=True)
+        X = self._val.observation_sequences(X, allow_single=True)
         self._val.boolean(verbose, desc='verbose')
         self._val.restricted_integer(n_jobs, lambda x: x == -1 or x > 0, 'number of jobs', '-1 or greater than zero')
 
@@ -145,7 +145,7 @@ class DTWKNN:
         confusion: numpy.ndarray
             The confusion matrix representing the discrepancy between predicted and actual labels.
         """
-        self._val.observation_sequences_and_labels(X, y)
+        X, y = self._val.observation_sequences_and_labels(X, y)
         self._val.boolean(verbose, desc='verbose')
 
         if labels is not None:

--- a/lib/sequentia/classifiers/hmm/hmm.py
+++ b/lib/sequentia/classifiers/hmm/hmm.py
@@ -81,7 +81,7 @@ class HMM:
             | The number of jobs to run in parallel.
             | Setting this to -1 will use all available CPU cores.
         """
-        self._val.observation_sequences(X)
+        X = self._val.observation_sequences(X)
         self._val.restricted_integer(n_jobs, lambda x: x == -1 or x > 0, 'number of jobs', '-1 or greater than zero')
 
         try:
@@ -131,10 +131,7 @@ class HMM:
         except AttributeError as e:
             raise AttributeError('The model must be fitted before running the forward algorithm') from e
 
-        if not isinstance(sequence, np.ndarray):
-            raise TypeError('Sequence of observations must be a numpy.ndarray')
-        if not sequence.ndim == 2:
-            raise ValueError('Sequence of observations must be two-dimensional')
+        sequence = self._val.observation_sequences(sequence, allow_single=True)
         if not sequence.shape[1] == self._n_features:
             raise ValueError('Number of observation features must match the dimensionality of the original data used to fit the model')
 

--- a/lib/sequentia/classifiers/hmm/hmm_classifier.py
+++ b/lib/sequentia/classifiers/hmm/hmm_classifier.py
@@ -61,7 +61,7 @@ class HMMClassifier:
         """
         self._val.boolean(prior, desc='prior')
         self._val.boolean(return_scores, desc='return_scores')
-        self._val.observation_sequences(X, allow_single=True)
+        X = self._val.observation_sequences(X, allow_single=True)
 
         try:
             self._models
@@ -111,7 +111,7 @@ class HMMClassifier:
         confusion: numpy.ndarray
             The confusion matrix representing the discrepancy between predicted and actual labels.
         """
-        self._val.observation_sequences_and_labels(X, y)
+        X, y = self._val.observation_sequences_and_labels(X, y)
         self._val.boolean(prior, desc='prior')
 
         if labels is not None:

--- a/lib/sequentia/preprocessing/methods.py
+++ b/lib/sequentia/preprocessing/methods.py
@@ -16,7 +16,7 @@ def trim_zeros(X):
         The zero-trimmed input observation sequence(s).
     """
     val = _Validator()
-    val.observation_sequences(X, allow_single=True)
+    X = val.observation_sequences(X, allow_single=True)
     return _trim_zeros(X)
 
 def _trim_zeros(X):
@@ -42,7 +42,7 @@ def center(X):
         The centered input observation sequence(s).
     """
     val = _Validator()
-    val.observation_sequences(X, allow_single=True)
+    X = val.observation_sequences(X, allow_single=True)
     return _center(X)
 
 def _center(X):
@@ -69,7 +69,7 @@ def standardize(X):
         The standardized input observation sequence(s).
     """
     val = _Validator()
-    val.observation_sequences(X, allow_single=True)
+    X = val.observation_sequences(X, allow_single=True)
     return _standardize(X)
 
 def _standardize(X):
@@ -104,7 +104,7 @@ def downsample(X, n, method='decimate'):
         The downsampled input observation sequence(s).
     """
     val = _Validator()
-    val.observation_sequences(X, allow_single=True)
+    X = val.observation_sequences(X, allow_single=True)
     val.restricted_integer(n, lambda x: x > 1, desc='downsample factor', expected='greater than one')
     val.one_of(method, ['decimate', 'average'], desc='downsampling method')
 
@@ -147,7 +147,7 @@ def fft(X):
         The transformed input observation sequence(s).
     """
     val = _Validator()
-    val.observation_sequences(X, allow_single=True)
+    X = val.observation_sequences(X, allow_single=True)
     return _fft(X)
 
 def _fft(X):
@@ -179,7 +179,7 @@ def filtrate(X, n, method='median'):
         The filtered input observation sequence(s).
     """
     val = _Validator()
-    val.observation_sequences(X, allow_single=True)
+    X = val.observation_sequences(X, allow_single=True)
     val.restricted_integer(n, lambda x: x > 1, desc='window size', expected='greater than one')
     val.one_of(method, ['median', 'mean'], desc='filtering method')
 

--- a/lib/sequentia/preprocessing/preprocess.py
+++ b/lib/sequentia/preprocessing/preprocess.py
@@ -74,9 +74,7 @@ class Preprocess:
         transformed: numpy.ndarray or List[numpy.ndarray]
             The input observation sequence(s) with preprocessing transformations applied in order.
         """
-        self._val.observation_sequences(X, allow_single=True)
-
-        X_transform = X
+        X_transform = self._val.observation_sequences(X, allow_single=True)
         for transform, kwargs in self._transforms:
             if transform == _downsample:
                 if isinstance(X_transform, np.ndarray):

--- a/lib/test/lib/internals/test_validator.py
+++ b/lib/test/lib/internals/test_validator.py
@@ -1,8 +1,7 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
 from sequentia.internals import _Validator
-from ...support import assert_equal
+from ...support import assert_equal, assert_all_equal
 
 val = _Validator()
 
@@ -13,19 +12,22 @@ val = _Validator()
 def test_single_observation_sequence_with_single():
     """Single observation sequence with allow_single=True"""
     x = np.arange(8).reshape(-1, 2)
-    assert_array_equal(x, val.observation_sequences(x, allow_single=True))
+    assert_equal(x, val.observation_sequences(x, allow_single=True))
 
 def test_single_observation_sequence_1d_flat_with_single():
     """Single flat 1D observation sequence with allow_single=True"""
     x = np.arange(4)
-    with pytest.raises(ValueError) as e:
-        val.observation_sequences(x, allow_single=True)
-    assert str(e.value) == 'Observation sequence must be two-dimensional'
+    assert_equal(val.observation_sequences(x, allow_single=True), np.array([
+        [0],
+        [1],
+        [2],
+        [3]
+    ]))
 
 def test_single_observation_sequence_1d_with_single():
     """Single non-flat 1D observation sequence with allow_single=True"""
     x = np.arange(4).reshape(-1, 1)
-    assert_array_equal(x, val.observation_sequences(x, allow_single=True))
+    assert_equal(x, val.observation_sequences(x, allow_single=True))
 
 def test_single_observation_sequence_wrong_type_with_single():
     """Single observation sequence with wrong type and allow_single=True"""
@@ -37,7 +39,7 @@ def test_single_observation_sequence_wrong_type_with_single():
 def test_multiple_observation_sequences_with_single():
     """Multiple observation sequences with allow_single=True"""
     X = [np.arange(8).reshape(-1, 2), np.arange(12).reshape(-1, 2)]
-    assert X == val.observation_sequences(X, allow_single=True)
+    assert_all_equal(X, val.observation_sequences(X, allow_single=True))
 
 def test_multiple_observation_sequences_diff_dims_with_single():
     """Multiple observation sequences with different dimensionality and allow_single=True"""
@@ -48,22 +50,38 @@ def test_multiple_observation_sequences_diff_dims_with_single():
 
 def test_multiple_observation_sequences_1d_some_flat_with_single():
     """Multiple 1D (flat and non-flat) observation sequences with allow_single=True"""
-    X = [np.arange(4).reshape(-1, 1), np.arange(8)]
-    with pytest.raises(ValueError) as e:
-        val.observation_sequences(X, allow_single=True)
-    assert str(e.value) == 'Each observation sequence must be two-dimensional'
+    X = [np.arange(2).reshape(-1, 1), np.arange(3)]
+    assert_all_equal(val.observation_sequences(X, allow_single=True), [
+        np.array([
+            [0],
+            [1]
+        ]),
+        np.array([
+            [0],
+            [1],
+            [2]
+        ])
+    ])
 
 def test_multiple_observation_sequences_1d_all_flat_with_single():
     """Multiple flat 1D observation sequences with allow_single=True"""
-    X = [np.arange(4), np.arange(8)]
-    with pytest.raises(ValueError) as e:
-        val.observation_sequences(X, allow_single=True)
-    assert str(e.value) == 'Each observation sequence must be two-dimensional'
+    X = [np.arange(2), np.arange(3)]
+    assert_all_equal(val.observation_sequences(X, allow_single=True), [
+        np.array([
+            [0],
+            [1]
+        ]),
+        np.array([
+            [0],
+            [1],
+            [2]
+        ])
+    ])
 
 def test_multiple_observation_sequences_1d_with_single():
     """Multiple 1D observation sequences with allow_single=True"""
     X = [np.arange(8).reshape(-1, 1), np.arange(12).reshape(-1, 1)]
-    assert X == val.observation_sequences(X, allow_single=True)
+    assert_all_equal(X, val.observation_sequences(X, allow_single=True))
 
 def test_multiple_observation_sequences_some_wrong_type_with_single():
     """Multiple observation sequences with different types and allow_single=True"""
@@ -95,10 +113,12 @@ def test_single_observation_sequence_without_single():
 
 def test_single_observation_sequence_1d_flat_without_single():
     """Single flat 1D observation sequence with allow_single=False"""
-    x = np.arange(4)
-    with pytest.raises(TypeError) as e:
-        val.observation_sequences(x, allow_single=False)
-    assert str(e.value) == 'Expected a list of observation sequences, each of type numpy.ndarray'
+    x = np.arange(3)
+    assert_equal(val.observation_sequences(x, allow_single=True), np.array([
+        [0],
+        [1],
+        [2]
+    ]))
 
 def test_single_observation_sequence_1d_without_single():
     """Single non-flat 1D observation sequence with allow_single=False"""
@@ -117,7 +137,7 @@ def test_single_observation_sequence_wrong_type_without_single():
 def test_multiple_observation_sequences_without_single():
     """Multiple observation sequences with allow_single=False"""
     X = [np.arange(8).reshape(-1, 2), np.arange(12).reshape(-1, 2)]
-    assert X == val.observation_sequences(X, allow_single=False)
+    assert_all_equal(X, val.observation_sequences(X, allow_single=False))
 
 def test_multiple_observation_sequences_diff_dims_without_single():
     """Multiple observation sequences with different dimensionality and allow_single=False"""
@@ -128,22 +148,38 @@ def test_multiple_observation_sequences_diff_dims_without_single():
 
 def test_multiple_observation_sequences_1d_some_flat_without_single():
     """Multiple 1D (flat and non-flat) observation sequences with allow_single=False"""
-    X = [np.arange(4).reshape(-1, 1), np.arange(8)]
-    with pytest.raises(ValueError) as e:
-        val.observation_sequences(X, allow_single=False)
-    assert str(e.value) == 'Each observation sequence must be two-dimensional'
+    X = [np.arange(2).reshape(-1, 1), np.arange(3)]
+    assert_all_equal(val.observation_sequences(X, allow_single=False), [
+        np.array([
+            [0],
+            [1]
+        ]),
+        np.array([
+            [0],
+            [1],
+            [2]
+        ])
+    ])
 
 def test_multiple_observation_sequences_1d_all_flat_without_single():
     """Multiple flat 1D observation sequences with allow_single=False"""
-    X = [np.arange(4), np.arange(8)]
-    with pytest.raises(ValueError) as e:
-        val.observation_sequences(X, allow_single=False)
-    assert str(e.value) == 'Each observation sequence must be two-dimensional'
+    X = [np.arange(2), np.arange(3)]
+    assert_all_equal(val.observation_sequences(X, allow_single=False), [
+        np.array([
+            [0],
+            [1]
+        ]),
+        np.array([
+            [0],
+            [1],
+            [2]
+        ])
+    ])
 
 def test_multiple_observation_sequences_1d_without_single():
     """Multiple 1D observation sequences with allow_single=False"""
     X = [np.arange(8).reshape(-1, 1), np.arange(12).reshape(-1, 1)]
-    assert X == val.observation_sequences(X, allow_single=False)
+    assert_all_equal(X, val.observation_sequences(X, allow_single=False))
 
 def test_multiple_observation_sequence_some_wrong_type_without_single():
     """Multiple observation sequences with different types and allow_single=False"""

--- a/notebooks/1 - Input Format (Tutorial).ipynb
+++ b/notebooks/1 - Input Format (Tutorial).ipynb
@@ -37,9 +37,7 @@
     "> - $T$ is the duration of the observation sequence, or number of frames.\n",
     "> - $D$ is the dimensionality of the observation sequence, or number of features.\n",
     "\n",
-    "---\n",
-    "\n",
-    "**Note**: In order to use univariate observation sequences, Sequentia expects the shape of these sequences to be `(T, 1)` rather than `(T,)` – *there is a difference*! To convert an observation sequence NumPy array `x` of shape `(T,)` to `(T, 1)`, you can either do `x.reshape(-1, 1)` or `x[:, None]`."
+    "However, one-dimensional Numpy arrays are also supported."
    ]
   },
   {

--- a/notebooks/2 - Preprocessing (Tutorial).ipynb
+++ b/notebooks/2 - Preprocessing (Tutorial).ipynb
@@ -72,15 +72,15 @@
     "xs = np.arange(-4., 4., 0.025)\n",
     "\n",
     "# Create two lambdas that define the features of the observation sequence\n",
-    "f1 = lambda x: (np.sin(x) - np.sin(np.exp(-0.7 * x))).reshape(-1, 1)\n",
-    "f2 = lambda x: (np.exp(np.cos(2*x)) * np.cos(x - 5)).reshape(-1, 1)\n",
+    "f1 = lambda x: (np.sin(x) - np.sin(np.exp(-0.7 * x)))\n",
+    "f2 = lambda x: (np.exp(np.cos(2*x)) * np.cos(x - 5))\n",
     "# Auxilliary function for downsampling the domain (for plotting)\n",
-    "d = lambda x, n: downsample(x.reshape(-1, 1), n=n, method='decimate')\n",
+    "d = lambda x, n: downsample(x, n=n, method='decimate')\n",
     "\n",
     "# Compute function values evaluated on the provided domain (xs)\n",
     "F1, F2 = f1(xs), f2(xs)\n",
     "# Combine F1 and F2 to form the features for the multivariate sequence F\n",
-    "F = np.hstack((F1, F2))\n",
+    "F = np.vstack((F1, F2)).T\n",
     "\n",
     "plt.figure(figsize=(20, 5))\n",
     "plt.title('Multivariate ($D=2$) observation sequence F composed of features F1 and F2', fontsize=16)\n",
@@ -375,7 +375,7 @@
     {
      "data": {
       "text/plain": [
-       "array([-8.56953397e-17, -5.93275429e-17])"
+       "array([-6.66133815e-17, -4.44089210e-17])"
       ]
      },
      "execution_count": 8,
@@ -447,7 +447,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean: [1.80411242e-17 5.86336535e-17]\n",
+      "Mean: [ 0.00000000e+00 -2.22044605e-17]\n",
       "Deviation: [1. 1.]\n"
      ]
     }
@@ -807,8 +807,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3min 56s, sys: 2.91 s, total: 3min 59s\n",
-      "Wall time: 4min 8s\n"
+      "CPU times: user 4min 16s, sys: 3.23 s, total: 4min 19s\n",
+      "Wall time: 4min 51s\n"
      ]
     }
    ],
@@ -880,8 +880,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3min 51s, sys: 2.61 s, total: 3min 54s\n",
-      "Wall time: 4min\n"
+      "CPU times: user 4min 14s, sys: 3.32 s, total: 4min 17s\n",
+      "Wall time: 4min 56s\n"
      ]
     }
    ],

--- a/notebooks/Pen-Tip Trajectories (Example).ipynb
+++ b/notebooks/Pen-Tip Trajectories (Example).ipynb
@@ -406,7 +406,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f66176e2ef834183bfc6bc800eb472f3",
+       "model_id": "d7129787d7374f0c86cd69bcd025ae06",
        "version_major": 2,
        "version_minor": 0
       },
@@ -448,7 +448,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "37e42c2c1ae5477d92146999bb781c5e",
+       "model_id": "22a01020548342138848d269ed00358a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -466,8 +466,8 @@
       "\n",
       "w c d e a e b h s v c y w e v v w v v p\n",
       "\n",
-      "CPU times: user 1min 22s, sys: 1.15 s, total: 1min 24s\n",
-      "Wall time: 1min 26s\n"
+      "CPU times: user 1min 12s, sys: 1.57 s, total: 1min 14s\n",
+      "Wall time: 1min 13s\n"
      ]
     }
    ],
@@ -496,8 +496,8 @@
      "text": [
       "w c d e a e b h s v c y w e v v w v v p\n",
       "\n",
-      "CPU times: user 590 ms, sys: 92.2 ms, total: 682 ms\n",
-      "Wall time: 50.8 s\n"
+      "CPU times: user 501 ms, sys: 78.4 ms, total: 579 ms\n",
+      "Wall time: 38.4 s\n"
      ]
     }
    ],
@@ -526,8 +526,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 578 ms, sys: 160 ms, total: 738 ms\n",
-      "Wall time: 22min 47s\n"
+      "CPU times: user 534 ms, sys: 196 ms, total: 730 ms\n",
+      "Wall time: 22min 36s\n"
      ]
     }
    ],
@@ -612,7 +612,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b5adce4c42340a8aaef1f2b6e5730fe",
+       "model_id": "32667796594d4a99b1aaec881433d6d1",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
- Remove strict requirement of Numpy arrays being two-dimensional by using `numpy.atleast_2d` to convert one-dimensional arrays into 2D.