### PR TITLE
[patch:ci] Fix pomegranate to v0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     python_requires='>=3.5,<3.8',
     install_requires = [
         'numpy>=1.17,<2',
-        'pomegranate>=0.11,<1',
+        'pomegranate==0.12.0',
         'fastdtw>=0.3,<0.4',
         'scipy>=1.3,<2',
         'scikit-learn>=0.22,<1',


### PR DESCRIPTION
- Fix `pomegranate` to v0.12.0 for the time being, due to wheel-building issues in Travis builds.