### PR TITLE
[patch:pkg] Fix setup.py encoding problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
 
 VERSION = '0.10.2'
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'r', encoding="utf8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
encoding problem in setup.py caused a problem installing the package from pip.
adding utf-8 solved it.