### PR TITLE
[patch:docs] Prevent search engines from indexing old versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ except ImportError:
     sys.path.insert(0, os.path.abspath('../lib'))
     import sequentia
 
-subprocess.call('pip install numpydoc sphinx_rtd_theme m2r2', shell=True)
+subprocess.call('pip install numpydoc sphinx_rtd_theme m2r2 sphinx-version-warning', shell=True)
 
 # -- Project information -----------------------------------------------------
 
@@ -42,7 +42,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'numpydoc',
     'm2r2',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
+    'versionwarning.extension'
 ]
 
 intersphinx_mapping = {'numpy': ('http://docs.scipy.org/doc/numpy/', None)}

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /*/latest/
+Allow: /en/latest/   # Fallback for bots that don't understand wildcards
+Allow: /*/stable/
+Allow: /en/stable/   # Fallback for bots that don't understand wildcards
+Disallow: /


### PR DESCRIPTION
- Add `docs/robots.txt` and `sphinx-version-warning` package to prevent search engines from indexing old package versions (see #143).