### PR TITLE
fix parallel read-only buffer source array

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Sequentia aims to follow the Scikit-Learn interface for estimators and transform
 as well as to be largely compatible with three core Scikit-Learn modules to improve the ease of model development:
 [`preprocessing`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing), [`model_selection`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.model_selection) and [`pipeline`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.pipeline).
 
-While there are many other important modules, full compatibility with Scikit-Learn is challenging and many of its features are in fact inapplicable to sequential data, therefore we only focus on the relevant core modules.
+While there are many other modules, maintaining full compatibility with Scikit-Learn is challenging and many of its features are inapplicable to sequential data, therefore we only focus on the relevant core modules.
 
 Despite some deviation from the Scikit-Learn interface in order to accommodate sequences, the following features are currently compatible with Sequentia.
 
@@ -119,6 +119,13 @@ For optimal performance when using any of the k-NN based models, it is important
 
 Please see the [`dtaidistance` installation guide](https://dtaidistance.readthedocs.io/en/latest/usage/installation.html) for troubleshooting if you run into C compilation issues, or if setting `use_c=True` on k-NN based models results in a warning.
 
+You can use the following to check if the appropriate C libraries have been installed.
+
+```python
+from dtaidistance import dtw
+dtw.try_import_c()
+```
+
 ### Pre-release
 
 Pre-release versions include new features which are in active development and may change unpredictably.
@@ -139,7 +146,7 @@ Documentation for the package is available on [Read The Docs](https://sequentia.
 
 ## Examples
 
-This example demonstrates multivariate sequence classification with two features and two classes, using the `KNNClassifier`.
+Demonstration of classifying multivariate sequences with two features into two classes using the `KNNClassifier`.
 
 This example also shows a typical preprocessing workflow, as well as compatibility with Scikit-Learn.
 

--- a/lib/sequentia/models/hmm/classifier.py
+++ b/lib/sequentia/models/hmm/classifier.py
@@ -405,7 +405,7 @@ class HMMClassifier(_Classifier):
         n_jobs = _effective_n_jobs(self.n_jobs, data.lengths)
         chunk_idxs = np.array_split(SequentialDataset._get_idxs(data.lengths), n_jobs)
         return np.concatenate(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._compute_scores_chunk)(idxs, data.X)
                 for idxs in chunk_idxs
             )

--- a/lib/sequentia/models/knn/base.py
+++ b/lib/sequentia/models/knn/base.py
@@ -166,7 +166,7 @@ class _KNNMixin:
         col_chunk_idxs = np.array_split(self.idxs_, n_jobs)
 
         return np.vstack(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._distance_matrix_row_chunk)(
                     row_idxs, col_chunk_idxs, data.X, n_jobs, dtw_
                 ) for row_idxs in row_chunk_idxs
@@ -371,7 +371,7 @@ class _KNNMixin:
         TODO
         """
         return np.hstack(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._distance_matrix_row_col_chunk)(
                     col_idxs, row_idxs, X, dist
                 ) for col_idxs in col_chunk_idxs

--- a/lib/sequentia/models/knn/classifier.py
+++ b/lib/sequentia/models/knn/classifier.py
@@ -354,7 +354,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         n_jobs = _effective_n_jobs(self.n_jobs, scores)
         score_chunks = np.array_split(scores, n_jobs)
         return np.concatenate(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._find_max_labels_chunk)(score_chunk)
                 for score_chunk in score_chunks
             )

--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,14 @@ setup(
     python_requires = '>=3.8',
     setup_requires = [
         'Cython>=0.28.5',
-        'numpy>=1.17',
+        'numpy>=1.18,<1.24',
         'scipy>=1.3',
     ],
     install_requires = [
         'numba>=0.56',
-        'numpy>=1.17',
+        'numpy>=1.18,<1.24',
         'hmmlearn>=0.2.8',
-        'dtaidistance[numpy]>=2.2',
+        'dtaidistance>=2.3.10', # [numpy]
         'scikit-learn>=1.0',
         'joblib>=0.14',
         'pydantic<1.9',


### PR DESCRIPTION
- Set `max_nbytes=None` to fix read-only buffer source array error in `joblib.Parallel` (see https://github.com/scikit-learn/scikit-learn/issues/7981).