### PR TITLE
release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.1.0](https://github.com/eonu/sequentia/releases/tag/v1.1.0)
+
+#### Major changes
+
+- Set `max_nbytes=None` to fix read-only buffer source array error in `joblib.Parallel` (see https://github.com/scikit-learn/scikit-learn/issues/7981). ([#235](https://github.com/eonu/sequentia/pull/235))
+- Added `sequentia.preprocessing` module with [`sklearn.preprocessing`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing) compatibility. ([#234](https://github.com/eonu/sequentia/pull/234))
+- Added `sequentia.pipeline` module for [`sklearn.pipeline`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.pipeline) compatibility. ([#234](https://github.com/eonu/sequentia/pull/234))
+
+#### Minor changes
+
+- Upgrade `sklearn` version specifier from `>=0.22` to `>=1.0`. ([#234](https://github.com/eonu/sequentia/pull/234))
+- Upgrade development status classifier to stable. ([#233](https://github.com/eonu/sequentia/pull/233))
+
+
 ## [1.0.0](https://github.com/eonu/sequentia/releases/tag/v1.0.0)
 
 #### Major changes
@@ -14,11 +28,13 @@
 - Remove `SequentialDataset.__eq__`. ([#231](https://github.com/eonu/sequentia/issues/231))
 - Change `HMMClassifier` `prior` default to `None`. ([#231](https://github.com/eonu/sequentia/issues/231))
 
+
 ## [1.0.0a2](https://github.com/eonu/sequentia/releases/tag/v1.0.0a2)
 
 #### Minor changes
 
 - Fix broken link on README.md. ([#229](https://github.com/eonu/sequentia/issues/229))
+
 
 ## [1.0.0a1](https://github.com/eonu/sequentia/releases/tag/v1.0.0a1)
 
@@ -35,11 +51,13 @@
 - Documentation rework + switch Sphinx documentation theme. ([#226](https://github.com/eonu/sequentia/issues/226))
 - Fix Sakoe-Chiba width calculation. ([#226](https://github.com/eonu/sequentia/issues/226))
 
+
 ## [0.13.1](https://github.com/eonu/sequentia/releases/tag/v0.13.1)
 
 #### Major changes
 
 - Add `digits.npz` as package data in `setup.py`. ([#221](https://github.com/eonu/sequentia/issues/221))
+
 
 ## [0.13.0](https://github.com/eonu/sequentia/releases/tag/v0.13.0)
 
@@ -66,6 +84,7 @@
 - Update `README.md` and documentation. ([#202](https://github.com/eonu/sequentia/issues/202))
 - Add `Jinja2` dependency for RTD. ([#188](https://github.com/eonu/sequentia/issues/188))
 
+
 ## [0.12.1](https://github.com/eonu/sequentia/releases/tag/v0.12.1)
 
 > - `KNNClassifier` has a major bug in all versions prior to and including v0.12.1 resulting in inaccurate predictions (see [#186](https://github.com/eonu/sequentia/issues/186)).
@@ -77,9 +96,11 @@
 
 - Remove `requirements.py` due to import error. ([#182](https://github.com/eonu/sequentia/pull/182))
 
+
 ## [0.12.0](https://github.com/eonu/sequentia/releases/tag/v0.12.0)
 
 #### Major changes
+
 - Rework preprocessing module (see [#177](https://github.com/eonu/sequentia/pull/177)). ([#179](https://github.com/eonu/sequentia/pull/179))
   - Add `Custom` transformation.
   - Rename `Preprocess` to `Compose`.
@@ -98,6 +119,7 @@
 - Add `sequentia[torch]` extra for optional `torch` CPU installation. ([#169](https://github.com/eonu/sequentia/pull/169))
 
 #### Minor changes
+
 - Keep batch lengths on CPU ([pytorch/pytorch#43227](https://github.com/pytorch/pytorch/issues/43227)). ([#178](https://github.com/eonu/sequentia/pull/178))
 - Remove `docs/requirements.txt` and specify `docs` extra in `.readthedocs.yml`. ([#176](https://github.com/eonu/sequentia/pull/176))
 - Move Sphinx extensions from `docs/conf.py` to `requirements.py`. ([#176](https://github.com/eonu/sequentia/pull/176))
@@ -109,24 +131,30 @@
 - Fix patch description in `CONTRIBUTING.md`. ([#170](https://github.com/eonu/sequentia/pull/170))
 - Fix wording in `README.md`. ([#167](https://github.com/eonu/sequentia/pull/167), [#168](https://github.com/eonu/sequentia/pull/168))
 
+
 ## [0.11.1](https://github.com/eonu/sequentia/releases/tag/v0.11.1)
 
 #### Major changes
+
 - Fix validation for univariate sequences. ([#164](https://github.com/eonu/sequentia/pull/164))
 
 #### Minor changes
+
 - Clean up `README.md` and add examples. ([#165](https://github.com/eonu/sequentia/pull/165))
 - Clean up validation logical expressions. ([#164](https://github.com/eonu/sequentia/pull/164))
+
 
 ## [0.11.0](https://github.com/eonu/sequentia/releases/tag/v0.11.0)
 
 #### Major changes
+
 - Add trailing underscore to variables containing trainable parameters (see #154). ([#158](https://github.com/eonu/sequentia/pull/158))
 - Add properties for GMM emission distribution parameters (see #153). ([#156](https://github.com/eonu/sequentia/pull/156))
 - Add selective `GMMHMM` parameter freezing/unfreezing (see #150). ([#155](https://github.com/eonu/sequentia/pull/155))
 - Fix random transition matrix initialization for `_LeftRightTopology` (see #149). ([#151](https://github.com/eonu/sequentia/pull/151))
 
 #### Minor changes
+
 - Add access to Baum-Welch algorithm convergence monitor (see #139). ([#162](https://github.com/eonu/sequentia/pull/162))
 - Prefix `_Validator` functions with `is_` (see #159). ([#161](https://github.com/eonu/sequentia/pull/161))
 - Add validation for checking fitted parameters (see #157). ([#160](https://github.com/eonu/sequentia/pull/160))
@@ -134,36 +162,46 @@
 - Add classifier documentation links to `README.md`. ([#152](https://github.com/eonu/sequentia/pull/152))
 - Simplify random transition matrix initialization for `_LinearTopology` and `_LeftRightTopology`. ([#151](https://github.com/eonu/sequentia/pull/151))
 
+
 ## [0.10.3](https://github.com/eonu/sequentia/releases/tag/v0.10.3)
 
 #### Major changes
+
 - Fix `setup.py` encoding problem. ([#145](https://github.com/eonu/sequentia/pull/145))
 - Add `docs/robots.txt` and `sphinx-version-warning` package to prevent search engines from indexing old package versions (see #143). ([#147](https://github.com/eonu/sequentia/pull/147))
 
 #### Minor changes
+
 - Add @Prhmma as a contributor for #145. ([#146](https://github.com/eonu/sequentia/pull/146))
+
 
 ## [0.10.2](https://github.com/eonu/sequentia/releases/tag/v0.10.2)
 
 #### Major changes
+
 - Add support for dependent feature warping (addresses [#124](https://github.com/eonu/sequentia/pull/124)). ([#135](https://github.com/eonu/sequentia/pull/135))
 - Add multi-processed predictions for `HMMClassifier` (addresses [#121](https://github.com/eonu/sequentia/pull/121)). ([#136](https://github.com/eonu/sequentia/pull/136))
 - Re-order `predict()` and `evaluate()` arguments. ([#138](https://github.com/eonu/sequentia/pull/138))
 
 #### Minor changes
+
 - Add `original_labels` documentation to `KNNClassifier`. ([#133](https://github.com/eonu/sequentia/pull/133))
 - Simplify `GMMHMM` documentation. ([#134](https://github.com/eonu/sequentia/pull/134))
 - Fix posterior comment in `classifier.svg`. ([#137](https://github.com/eonu/sequentia/pull/137))
 
+
 ## [0.10.1](https://github.com/eonu/sequentia/releases/tag/v0.10.1)
 
 #### Minor changes
+
 - Remove references to `sigment`. ([#130](https://github.com/eonu/sequentia/pull/130))
 - Fix type specifiers in documentation (see [#129](https://github.com/eonu/sequentia/issues/129)). ([#131](https://github.com/eonu/sequentia/pull/131))
+
 
 ## [0.10.0](https://github.com/eonu/sequentia/releases/tag/v0.10.0)
 
 #### Major changes
+
 - Switch out [`pomegranate`](https://github.com/jmschrei/pomegranate) HMM backend to [`hmmlearn`](https://github.com/hmmlearn/hmmlearn). ([#105](https://github.com/eonu/sequentia/pull/105))
 - Remove separate HMM and GMM-HMM implementations – only keep a single GMM-HMM implementation (in the `GMMHMM` class) and treat multivariate Gaussian emission HMM as a special case of GMM-HMM. ([#105](https://github.com/eonu/sequentia/pull/105))
 - Support string and numeric labels by using label encodings (from [`sklearn.preprocessing.LabelEncoder`](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html)). ([#105](https://github.com/eonu/sequentia/pull/105))
@@ -171,6 +209,7 @@
 - Switch from approximate DTW algorithm ([`fastdtw`](https://github.com/slaypni/fastdtw)) to exact implementation ([`dtaidistance`](https://github.com/wannesm/dtaidistance)) for `KNNClassifier`. ([#106](https://github.com/eonu/sequentia/pull/106))
 
 #### Minor changes
+
 - Switch to use duck-typing for iterables instead of requiring lists. ([#105](https://github.com/eonu/sequentia/pull/105))
 - Rename 'strict left-right' HMM topology to 'linear'. ([#105](https://github.com/eonu/sequentia/pull/105))
 - Switch `m2r` to `m2r2`, as `m2r` is no longer maintained. ([#105](https://github.com/eonu/sequentia/pull/105))
@@ -183,21 +222,27 @@
 - Use feature-independent warping (DTWI). ([#121](https://github.com/eonu/sequentia/pull/121))
 - Ensure minimum Sakoe-Chiba band width is 1. ([#126](https://github.com/eonu/sequentia/pull/126))
 
+
 ## [0.7.2](https://github.com/eonu/sequentia/releases/tag/v0.7.2)
 
 #### Major changes
+
 - Stop referring to sequences as temporal, as non-temporal sequences can also be used. ([#103](https://github.com/eonu/sequentia/pull/103))
+
 
 ## [0.7.1](https://github.com/eonu/sequentia/releases/tag/v0.7.1)
 
 #### Major changes
+
 - Fix deserialization for `KNNClassifier`. ([#93](https://github.com/eonu/sequentia/pull/93))
   - Sort HDF5 keys before loading as `numpy.ndarray`s.
   - Pass `weighting` function into deserialization constructor.
 
+
 ## [0.7.0](https://github.com/eonu/sequentia/releases/tag/v0.7.0)
 
 #### Major changes
+
 - Fix `pomegranate` version to v0.12.0. ([#79](https://github.com/eonu/sequentia/pull/79))
 - Add serialization and deserialization support for all classifiers. ([#80](https://github.com/eonu/sequentia/pull/80))
   - `HMM`, `HMMClassifier`: Serialized in JSON format.
@@ -211,29 +256,38 @@
 - Rename `DTWKNN` to `KNNClassifer`. ([#91](https://github.com/eonu/sequentia/pull/91))
 
 #### Minor changes
+
 - (_Internal_) Simplify package imports. ([#82](https://github.com/eonu/sequentia/pull/82))
 - (_Internal_) Add `Validator.func()` for validating callables. ([#90](https://github.com/eonu/sequentia/pull/90))
+
 
 ## [v0.7.0a1](https://github.com/eonu/sequentia/releases/tag/v0.7.0a1)
 
 #### Major changes
+
 - Clean up package imports. ([#77](https://github.com/eonu/sequentia/pull/77))
 - Rework `preprocessing` module. ([#75](https://github.com/eonu/sequentia/pull/75))
 
 #### Minor changes
+
 - Fix typos and update preprocessing information in `README.md`. ([#76](https://github.com/eonu/sequentia/pull/76))
+
 
 ## [0.6.1](https://github.com/eonu/sequentia/releases/tag/v0.6.1)
 
 #### Major changes
+
 - Remove strict requirement of Numpy arrays being two-dimensional by using `numpy.atleast_2d` to convert one-dimensional arrays into 2D. ([#70](https://github.com/eonu/sequentia/pull/70))
 
 #### Minor changes
+
 - As the HMM classifier is not a true ensemble of HMMs (since each HMM doesn't really contribute to the classification), it is no longer referred to as an ensemble. ([#69](https://github.com/eonu/sequentia/pull/69))
+
 
 ## [0.6.0](https://github.com/eonu/sequentia/releases/tag/v0.6.0)
 
 #### Major changes
+
 - Add package tests and Travis CI support. ([#56](https://github.com/eonu/sequentia/pull/56))
 - Remove Python v3.8+ support. ([#56](https://github.com/eonu/sequentia/pull/56))
 - Rename `normalize` preprocessing method to `center`, since it just centers an observation sequence. ([#62](https://github.com/eonu/sequentia/pull/62))
@@ -241,13 +295,16 @@
 - Add `trim_zeros` preprocessing method for removing zero-observations from an observation sequence. ([#67](https://github.com/eonu/sequentia/pull/67))
 
 #### Minor changes
+
 - Add `Validator.random_state` for validating random state objects and seeds. ([#56](https://github.com/eonu/sequentia/pull/56))
 - Internalize `Validator` and topology (`Topology`, `ErgodicTopology`, `LeftRightTopology`) classes. ([#57](https://github.com/eonu/sequentia/pull/57))
 - Use proper documentation format for topology classes. ([#58](https://github.com/eonu/sequentia/pull/58))
 
+
 ## [0.5.0](https://github.com/eonu/sequentia/releases/tag/v0.5.0)
 
 #### Major changes
+
 - Add `Preprocess.summary()` to display an ordered summary of preprocessing transformations. ([#54](https://github.com/eonu/sequentia/pull/54))
 - Add mean and median filtering preprocessing methods. ([#48](https://github.com/eonu/sequentia/pull/48))
 - Use median filtering and decimation downsampling by default. ([#52](https://github.com/eonu/sequentia/pull/52))
@@ -256,26 +313,34 @@
   - Modify downsampling method to downsample residual observations.
 
 #### Minor changes
+
 - Add supported topologies (left-right and ergodic) to feature list. ([#53](https://github.com/eonu/sequentia/pull/53))
 - Add restrictions on preprocessing parameters: downsample factor and window size. ([#50](https://github.com/eonu/sequentia/pull/50))
 - Allow `Preprocess` class to be used to apply preprocessing transformations to a single observation sequence. ([#49](https://github.com/eonu/sequentia/pull/49))
 
+
 ## [0.4.0](https://github.com/eonu/sequentia/releases/tag/v0.4.0)
 
 #### Major changes
+
 - Re-add `euclidean` metric as `DTWKNN` default. ([#43](https://github.com/eonu/sequentia/pull/43))
 
 #### Minor changes
+
 - Add explicit labels to `evaluate()` in `HMMClassifier` example. ([#44](https://github.com/eonu/sequentia/pull/44))
+
 
 ## [0.3.0](https://github.com/eonu/sequentia/releases/tag/v0.3.0)
 
 #### Major changes
+
 - Add proper documentation, hosted on [Read The Docs](https://sequentia.readthedocs.io/en/latest). ([#40](https://github.com/eonu/sequentia/pull/40), [#41](https://github.com/eonu/sequentia/pull/41))
+
 
 ## [0.2.0](https://github.com/eonu/sequentia/releases/tag/v0.2.0)
 
 #### Major changes
+
 - Add multi-processing support for `DTWKNN` predictions. ([#29](https://github.com/eonu/sequentia/pull/29))
 - Rename the `fit_transform()` function in `Preprocess` to `transform()` since there is nothing being fitted. ([#35](https://github.com/eonu/sequentia/pull/35))
 - Modify package classifiers in `setup.py` ([#31](https://github.com/eonu/sequentia/pull/31)):
@@ -284,13 +349,16 @@
   - Specify UNIX and macOS operating system classifiers.
 
 #### Minor changes
+
 - Finish tutorial and example notebooks. ([#35](https://github.com/eonu/sequentia/pull/35))
 - Rename `examples` directory to `notebooks`. ([#32](https://github.com/eonu/sequentia/pull/32))
 - Host notebooks statically on [nbviewer](https://github.com/jupyter/nbviewer). ([#32](https://github.com/eonu/sequentia/pull/32))
 - Add reference to Pomegranate [paper](http://jmlr.org/papers/volume18/17-636/17-636.pdf) and [repository](https://github.com/jmschrei/pomegranate). ([#30](https://github.com/eonu/sequentia/pull/30))
 - Add badges to `README.md`. ([#28](https://github.com/eonu/sequentia/pull/28))
 
+
 ## [0.1.0](https://github.com/eonu/sequentia/releases/tag/v0.1.0)
 
 #### Major changes
+
 Nothing, initial release!

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Sequentia aims to follow the Scikit-Learn interface for estimators and transform
 as well as to be largely compatible with three core Scikit-Learn modules to improve the ease of model development:
 [`preprocessing`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing), [`model_selection`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.model_selection) and [`pipeline`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.pipeline).
 
-While there are many other important modules, full compatibility with Scikit-Learn is challenging and many of its features are in fact inapplicable to sequential data, therefore we only focus on the relevant core modules.
+While there are many other modules, maintaining full compatibility with Scikit-Learn is challenging and many of its features are inapplicable to sequential data, therefore we only focus on the relevant core modules.
 
 Despite some deviation from the Scikit-Learn interface in order to accommodate sequences, the following features are currently compatible with Sequentia.
 
@@ -119,6 +119,13 @@ For optimal performance when using any of the k-NN based models, it is important
 
 Please see the [`dtaidistance` installation guide](https://dtaidistance.readthedocs.io/en/latest/usage/installation.html) for troubleshooting if you run into C compilation issues, or if setting `use_c=True` on k-NN based models results in a warning.
 
+You can use the following to check if the appropriate C libraries have been installed.
+
+```python
+from dtaidistance import dtw
+dtw.try_import_c()
+```
+
 ### Pre-release
 
 Pre-release versions include new features which are in active development and may change unpredictably.
@@ -139,7 +146,7 @@ Documentation for the package is available on [Read The Docs](https://sequentia.
 
 ## Examples
 
-This example demonstrates multivariate sequence classification with two features and two classes, using the `KNNClassifier`.
+Demonstration of classifying multivariate sequences with two features into two classes using the `KNNClassifier`.
 
 This example also shows a typical preprocessing workflow, as well as compatibility with Scikit-Learn.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@
     <a href="#examples">Examples</a> ·
     <a href="#acknowledgments">Acknowledgments</a> ·
     <a href="#references">References</a> ·
-    <a href="#contributors">Contributors</a>
+    <a href="#contributors">Contributors</a> ·
+    <a href="#licensing">Licensing</a>
   </sup>
 </p>
 
@@ -47,8 +48,7 @@ Some examples of how Sequentia can be used on sequence data include:
 
 - determining a spoken word based on its audio signal or alternative representations such as MFCCs,
 - predicting motion intent for gesture control from sEMG signals,
-- classifying hand-written characters according to their pen-tip trajectories,
-- predicting the gene family that a DNA sequence belongs to.
+- classifying hand-written characters according to their pen-tip trajectories.
 
 ## Build Status
 
@@ -58,27 +58,48 @@ Some examples of how Sequentia can be used on sequence data include:
 
 ## Features
 
+### Models
+
 The following models provided by Sequentia all support variable length sequences.
 
-- [x] [Dynamic Time Warping + k-Nearest Neighbors](https://sequentia.readthedocs.io/en/latest/sections/classifiers/knn.html) (via [`dtaidistance`](https://github.com/wannesm/dtaidistance))
-  - [x] Classification
-  - [x] Regression
-  - [x] Multivariate real-valued observations
-  - [x] Sakoe–Chiba band global warping constraint
-  - [x] Dependent and independent feature warping (DTWD/DTWI)
-  - [x] Custom distance-weighted predictions
-  - [x] Multi-processed predictions
-- [x] [Hidden Markov Models](https://sequentia.readthedocs.io/en/latest/sections/classifiers/gmmhmm.html) (via [`hmmlearn`](https://github.com/hmmlearn/hmmlearn))<br/><em>Parameter estimation with the Baum-Welch algorithm and prediction with the forward algorithm</em> [[1]](#references)
-  - [x] Classification
-  - [x] Multivariate real-valued observations (Gaussian mixture model emissions)
-  - [x] Univariate categorical observations (discrete emissions)
-  - [x] Linear, left-right and ergodic topologies
-  - [x] Multi-processed predictions
+#### [Dynamic Time Warping + k-Nearest Neighbors](https://sequentia.readthedocs.io/en/latest/sections/models/knn/index.html) (via [`dtaidistance`](https://github.com/wannesm/dtaidistance))
 
-  <p align="center">
-    <img src="https://raw.githubusercontent.com/eonu/sequentia/master/docs/_static/images/classifier.png" width="80%"/><br/>
-    HMM Sequence Classifier
-  </p>
+- [x] Classification
+- [x] Regression
+- [x] Multivariate real-valued observations
+- [x] Sakoe–Chiba band global warping constraint
+- [x] Dependent and independent feature warping (DTWD/DTWI)
+- [x] Custom distance-weighted predictions
+- [x] Multi-processed predictions
+
+#### [Hidden Markov Models](https://sequentia.readthedocs.io/en/latest/sections/models/hmm/index.html) (via [`hmmlearn`](https://github.com/hmmlearn/hmmlearn))
+
+Parameter estimation with the Baum-Welch algorithm and prediction with the forward algorithm [[1]](#references)
+
+- [x] Classification
+- [x] Multivariate real-valued observations (Gaussian mixture model emissions)
+- [x] Univariate categorical observations (discrete emissions)
+- [x] Linear, left-right and ergodic topologies
+- [x] Multi-processed predictions
+
+### Scikit-Learn compatibility
+
+Sequentia aims to follow the Scikit-Learn interface for estimators and transformations,
+as well as to be largely compatible with three core Scikit-Learn modules to improve the ease of model development:
+[`preprocessing`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing), [`model_selection`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.model_selection) and [`pipeline`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.pipeline).
+
+While there are many other important modules, full compatibility with Scikit-Learn is challenging and many of its features are in fact inapplicable to sequential data, therefore we only focus on the relevant core modules.
+
+Despite some deviation from the Scikit-Learn interface in order to accommodate sequences, the following features are currently compatible with Sequentia.
+
+- [x] [`preprocessing`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing)
+  - [x] [`FunctionTransformer`](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer) — via an adapted class definition
+  - [x] Function-based transformations (stateless)
+  - [x] Class-based transformations (stateful)
+- [ ] [`pipeline`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.pipeline)
+  - [x] [`Pipeline`](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn.pipeline.Pipeline) — via an adapted class definition
+  - [ ] [`FeatureUnion`](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.FeatureUnion.html#sklearn.pipeline.FeatureUnion)
+- [ ] [`model_selection`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.model_selection)
 
 ## Installation
 
@@ -118,40 +139,73 @@ Documentation for the package is available on [Read The Docs](https://sequentia.
 
 ## Examples
 
-This example demonstrates multivariate sequences classified into classes `0`/`1` using the `KNNClassifier`.
+This example demonstrates multivariate sequence classification with two features and two classes, using the `KNNClassifier`.
+
+This example also shows a typical preprocessing workflow, as well as compatibility with Scikit-Learn.
 
 ```python
 import numpy as np
+
+from sklearn.preprocessing import scale
+from sklearn.decomposition import PCA
+
 from sequentia.models import KNNClassifier
+from sequentia.pipeline import Pipeline
+from sequentia.preprocessing import IndependentFunctionTransformer, mean_filter
 
-# Generate training sequences and labels
-X = [
-  np.array([[1., 0., 5., 3., 7., 2., 2., 4., 9., 8., 7.],
-            [3., 8., 4., 0., 7., 1., 1., 3., 4., 2., 9.]]).T,
-  np.array([[2., 1., 4., 6., 5., 8.],
-            [5., 3., 9., 0., 8., 2.]]).T,
-  np.array([[5., 8., 0., 3., 1., 0., 2., 7., 9.],
-            [0., 2., 7., 1., 2., 9., 5., 8., 1.]]).T
-]
-y = [0, 1, 1]
+# Create input data
+# - Sequentia expects sequences to be concatenated into a single array
+# - Sequence lengths are provided separately and used to decode the sequences when needed
+# - This avoids the need for complex structures such as lists of arrays with different lengths
 
-# Sequentia expects a concatenated array of sequences (and their corresponding lengths)
-X, lengths = np.vstack(X), [len(x) for x in X]
+# Sequences
+X = np.array([
+    # Sequence 1 - Length 3
+    [1.2 , 7.91],
+    [1.34, 6.6 ],
+    [0.92, 8.08],
+    # Sequence 2 - Length 5
+    [2.11, 6.97],
+    [1.83, 7.06],
+    [1.54, 5.98],
+    [0.86, 6.37],
+    [1.21, 5.8 ],
+    # Sequence 3 - Length 2
+    [1.7 , 6.22],
+    [2.01, 5.49]
+])
 
-# Create and fit the classifier
-clf = KNNClassifier(k=1).fit(X, y, lengths)
+# Sequence lengths
+lengths = np.array([3, 5, 2])
 
-# Make a prediction for a new observation sequence
-x_new = np.array([[0., 3., 2., 7., 9., 1., 1.],
-                  [2., 5., 7., 4., 2., 0., 8.]]).T
-y_new = clf.predict(x_new)
+# Sequence classes
+y = np.array([0, 1, 1])
+
+# Create a transformation pipeline that feeds into a KNNClassifier
+# 1. Individually denoise each sequence by applying a mean filter for each feature
+# 2. Individually standardize each sequence by subtracting the mean and dividing the s.d. for each feature
+# 3. Reduce the dimensionality of the data to a single feature by using PCA
+# 4. Pass the resulting transformed data into a KNNClassifier
+pipeline = Pipeline([
+    ('denoise', IndependentFunctionTransformer(mean_filter)),
+    ('scale', IndependentFunctionTransformer(scale)),
+    ('pca', PCA(n_components=1)),
+    ('knn', KNNClassifier(k=1))
+])
+
+# Fit the pipeline to the data - lengths must be provided
+pipeline.fit(X, y, lengths)
+
+# Predict classes for the sequences and calculate accuracy - lengths must be provided
+y_pred = pipeline.predict(X, lengths)
+acc = pipeline.score(X, y, lengths)
 ```
 
 ## Acknowledgments
 
 In earlier versions of the package, an approximate DTW implementation [`fastdtw`](https://github.com/slaypni/fastdtw) was used in hopes of speeding up k-NN predictions, as the authors of the original FastDTW paper [[2]](#references) claim that approximated DTW alignments can be computed in linear memory and time, compared to the O(N<sup>2</sup>) runtime complexity of the usual exact DTW implementation.
 
-I was contacted by [Prof. Eamonn Keogh](https://www.cs.ucr.edu/~eamonn/) whose work [[3]](#references) makes the surprising revelation that FastDTW is generally slower than the exact DTW algorithm that it approximates. Upon switching from the `fastdtw` package to [`dtaidistance`](https://github.com/wannesm/dtaidistance) (a very solid implementation of exact DTW with fast pure C compiled functions), DTW k-NN prediction times were indeed reduced drastically.
+I was contacted by [Prof. Eamonn Keogh](https://www.cs.ucr.edu/~eamonn/) whose work makes the surprising revelation that FastDTW is generally slower than the exact DTW algorithm that it approximates [[3]](#references). Upon switching from the `fastdtw` package to [`dtaidistance`](https://github.com/wannesm/dtaidistance) (a very solid implementation of exact DTW with fast pure C compiled functions), DTW k-NN prediction times were indeed reduced drastically.
 
 I would like to thank Prof. Eamonn Keogh for directly reaching out to me regarding this finding.
 
@@ -216,9 +270,16 @@ All contributions to this repository are greatly appreciated. Contribution guide
 	</thead>
 </table>
 
+## Licensing
+
+Sequentia is released under the [MIT](https://opensource.org/licenses/MIT) license.
+
+Certain parts of the source code are heavily adapted from [Scikit-Learn](scikit-learn.org/).
+Such files contain copy of [their license](https://github.com/scikit-learn/scikit-learn/blob/main/COPYING).
+
 ---
 
 <p align="center">
-  <b>Sequentia</b> &copy; 2019-2023, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> License.<br/>
+  <b>Sequentia</b> &copy; 2019-2023, Edwin Onuonga - Released under the <a href="https://opensource.org/licenses/MIT">MIT</a> license.<br/>
   <em>Authored and maintained by Edwin Onuonga.</em>
 </p>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Features
    :titlesonly:
 
    sections/models/index
+   sections/preprocessing/index
    sections/datasets/index
 
 Documentation Search and Index

--- a/docs/sections/models/hmm/classifier.rst
+++ b/docs/sections/models/hmm/classifier.rst
@@ -53,6 +53,7 @@ Methods
    ~sequentia.models.hmm.classifier.HMMClassifier.add_model
    ~sequentia.models.hmm.classifier.HMMClassifier.add_models
    ~sequentia.models.hmm.classifier.HMMClassifier.fit
+   ~sequentia.models.hmm.classifier.HMMClassifier.fit_predict
    ~sequentia.models.hmm.classifier.HMMClassifier.predict
    ~sequentia.models.hmm.classifier.HMMClassifier.predict_proba
    ~sequentia.models.hmm.classifier.HMMClassifier.predict_scores

--- a/docs/sections/models/knn/classifier.rst
+++ b/docs/sections/models/knn/classifier.rst
@@ -6,10 +6,10 @@ The KNN Classifier is a classifier that uses the :math:`k`-NN algorithm with DTW
 To classify a sequence :math:`O'`, the :class:`.KNNClassifier` works by:
 
 1. | Calculating the **DTW distance** between :math:`O'` and every training sequence.
-   
+
 2. | Forming a **k-neighborhood** :math:`\mathcal{K}'=\left\{O^{(1)},\ldots,O^{(k)}\right\}` of the :math:`k` nearest training sequences to :math:`O'`.
 
-3. | Calculating a **distance weighting** for each sequence in :math:`\mathcal{K}'`. 
+3. | Calculating a **distance weighting** for each sequence in :math:`\mathcal{K}'`.
    | A uniform weighting of 1 is used by default, meaning that all sequences in :math:`\mathcal{K}'` have equal influence on the predicted class. However, custom functions such as :math:`e^{-x}` (where :math:`x` is the DTW distance) can be specified to increase classification weight on training sequences that are more similar to :math:`O'`.
 
 4. | Calculating a **score** for each of the unique classes corresponding to the sequences in :math:`\mathcal{K}'`.
@@ -37,6 +37,7 @@ Methods
    ~sequentia.models.knn.classifier.KNNClassifier.compute_distance_matrix
    ~sequentia.models.knn.classifier.KNNClassifier.dtw
    ~sequentia.models.knn.classifier.KNNClassifier.fit
+   ~sequentia.models.knn.classifier.KNNClassifier.fit_predict
    ~sequentia.models.knn.classifier.KNNClassifier.load
    ~sequentia.models.knn.classifier.KNNClassifier.plot_dtw_histogram
    ~sequentia.models.knn.classifier.KNNClassifier.plot_warping_path_1d

--- a/docs/sections/models/knn/regressor.rst
+++ b/docs/sections/models/knn/regressor.rst
@@ -6,14 +6,14 @@ The KNN Regressor is a regressor that uses the :math:`k`-NN algorithm with DTW a
 To predict an output :math:`y'\in\mathbb{R}` for a sequence :math:`O'`, the :class:`.KNNRegressor` works by:
 
 1. | Calculating the **DTW distance** between :math:`O'` and every training sequence.
-   
+
 2. | Forming a **k-neighborhood** :math:`\mathcal{K}'=\left\{O^{(1)},\ldots,O^{(k)}\right\}` of the :math:`k` nearest training sequences to :math:`O'`.
 
-3. | Calculating a **distance weighting** :math:`w^{(1)},\ldots,w^{(k)}` for each sequence in :math:`\mathcal{K}'`. 
+3. | Calculating a **distance weighting** :math:`w^{(1)},\ldots,w^{(k)}` for each sequence in :math:`\mathcal{K}'`.
    | A uniform weighting of 1 is used by default, meaning that all sequences in :math:`\mathcal{K}'` have equal influence on the predicted output :math:`y'`. However, custom functions such as :math:`e^{-x}` (where :math:`x` is the DTW distance) can be specified to increase weight on training sequences that are more similar to :math:`O'`.
 
 4. | Calculating :math:`y'` as the **distance weighted mean of the outputs** :math:`y^{(1)},\ldots,y^{(k)}` of sequences in :math:`\mathcal{K}'`.
-   
+
    .. math::
 
       y' = \frac{\sum_{k=1}^Kw^{(k)}y^{(k)}}{\sum_{k=1}^Kw^{(k)}}
@@ -41,6 +41,7 @@ Methods
    ~sequentia.models.knn.regressor.KNNRegressor.compute_distance_matrix
    ~sequentia.models.knn.regressor.KNNRegressor.dtw
    ~sequentia.models.knn.regressor.KNNRegressor.fit
+   ~sequentia.models.knn.regressor.KNNRegressor.fit_predict
    ~sequentia.models.knn.regressor.KNNRegressor.load
    ~sequentia.models.knn.regressor.KNNRegressor.plot_dtw_histogram
    ~sequentia.models.knn.regressor.KNNRegressor.plot_warping_path_1d

--- a/docs/sections/preprocessing/index.rst
+++ b/docs/sections/preprocessing/index.rst
@@ -1,0 +1,20 @@
+Preprocessing
+=============
+
+.. toctree::
+    :titlesonly:
+
+    pipeline
+    transforms/index
+
+----
+
+Sequentia provides an adapted version of the :mod:`sklearn.preprocessing` interface,
+modified for sequential data support but also continuing to support most of the Scikit-Learn transformations out-of-the-box.
+
+Transformations can be applied to all of the input sequences collectively — treated as a single array,
+or on an individual basis by using the :class:`.IndependentFunctionTransformer`.
+
+Transformation steps can be combined together with an estimator in a :class:`.Pipeline` which follows the Scikit-Learn interface.
+
+Additional transformations specific to sequences are also provided, such as :ref:`filters <filters>` for signal data.

--- a/docs/sections/preprocessing/pipeline.rst
+++ b/docs/sections/preprocessing/pipeline.rst
@@ -1,0 +1,41 @@
+Pipeline
+========
+
+Before fitting and using a model, it is common to apply a sequence of preprocessing steps to data.
+
+Pipelines can be used to wrap preprocessing transformations as well as a model into a single estimator,
+making it more convenient to reapply the transformations and make predictions on new data.
+
+The :class:`.Pipeline` class implements this feature and is based on :class:`sklearn.pipeline.Pipeline`.
+
+API reference
+-------------
+
+Class
+^^^^^
+
+.. autosummary::
+
+   ~sequentia.pipeline.Pipeline
+
+Methods
+^^^^^^^
+
+.. autosummary::
+
+   ~sequentia.pipeline.Pipeline.__init__
+   ~sequentia.pipeline.Pipeline.fit
+   ~sequentia.pipeline.Pipeline.fit_predict
+   ~sequentia.pipeline.Pipeline.fit_transform
+   ~sequentia.pipeline.Pipeline.inverse_transform
+   ~sequentia.pipeline.Pipeline.predict
+   ~sequentia.pipeline.Pipeline.predict_proba
+   ~sequentia.pipeline.Pipeline.score
+   ~sequentia.pipeline.Pipeline.transform
+
+|
+
+.. autoclass:: sequentia.pipeline.Pipeline
+   :members:
+   :inherited-members:
+   :exclude-members: decision_function, get_feature_names_out, get_params, set_params, set_output, predict_log_proba, score_samples, feature_names_in_

--- a/docs/sections/preprocessing/transforms/filters.rst
+++ b/docs/sections/preprocessing/transforms/filters.rst
@@ -1,0 +1,27 @@
+.. _filters:
+
+Filters
+=======
+
+Filters are a common preprocessing method for reducing noise in signal processing.
+
+:func:`.mean_filter` and :func:`.median_filter` can be applied to individual sequences.
+
+.. seealso::
+    Consider using :class:`.IndependentFunctionTransformer` to apply these filters to multiple sequences.
+
+API reference
+-------------
+
+Methods
+^^^^^^^
+
+.. autosummary::
+
+   ~sequentia.preprocessing.transforms.mean_filter
+   ~sequentia.preprocessing.transforms.median_filter
+
+|
+
+.. autofunction:: sequentia.preprocessing.transforms.mean_filter
+.. autofunction:: sequentia.preprocessing.transforms.median_filter

--- a/docs/sections/preprocessing/transforms/function_transformer.rst
+++ b/docs/sections/preprocessing/transforms/function_transformer.rst
@@ -1,0 +1,44 @@
+Function Transformer
+====================
+
+When preprocessing sequential data, it is often preferable to apply certain transformations
+on each sequence independently rather than applying a single transformation to all of the data collectively.
+
+For example in speech recognition, suppose we have a dataset of MFCC features extracted from audio recordings of different speakers.
+If we are not interested in speaker-focused tasks such as speaker recognition, and instead only want to classify recordings,
+we need to be able to compare recordings to each other — especially if using algorithms such as :class:`.KNNClassifier` which rely on distance comparisons.
+
+In this case, we might want to standardize the MFCCs for each recording individually, (i.e. centering and scaling by separate feature means and standard deviations for each recording) so that they are represented as deviations from zero,
+which is a form that is better suited for comparison as it reduces speaker-specific nuances in the data due to differences in scale or location.
+
+Another example would be signal filters, which should be applied to each sequence independently.
+
+:class:`.IndependentFunctionTransformer` allows for such transformations to be defined for arbitrary functions.
+
+API reference
+-------------
+
+Class
+^^^^^
+
+.. autosummary::
+
+   ~sequentia.preprocessing.transforms.IndependentFunctionTransformer
+
+Methods
+^^^^^^^
+
+.. autosummary::
+
+   ~sequentia.preprocessing.transforms.IndependentFunctionTransformer.__init__
+   ~sequentia.preprocessing.transforms.IndependentFunctionTransformer.fit
+   ~sequentia.preprocessing.transforms.IndependentFunctionTransformer.fit_transform
+   ~sequentia.preprocessing.transforms.IndependentFunctionTransformer.inverse_transform
+   ~sequentia.preprocessing.transforms.IndependentFunctionTransformer.transform
+
+|
+
+.. autoclass:: sequentia.preprocessing.transforms.IndependentFunctionTransformer
+   :members:
+   :inherited-members:
+   :exclude-members: get_params, set_params, set_output

--- a/docs/sections/preprocessing/transforms/index.rst
+++ b/docs/sections/preprocessing/transforms/index.rst
@@ -1,0 +1,8 @@
+Transforms
+==========
+
+.. toctree::
+    :titlesonly:
+
+    filters
+    function_transformer

--- a/lib/sequentia/__init__.py
+++ b/lib/sequentia/__init__.py
@@ -5,7 +5,7 @@ from .pipeline import *
 from .utils import *
 
 __name__ = "sequentia"
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "Edwin Onuonga"
 __email__ = "ed@eonu.net"
 __copyright__ = f"2019-2023, {__author__}"

--- a/lib/sequentia/__init__.py
+++ b/lib/sequentia/__init__.py
@@ -1,6 +1,7 @@
 from .datasets import *
 from .models import *
-# from .preprocessing import *
+from .preprocessing import *
+from .pipeline import *
 from .utils import *
 
 __name__ = "sequentia"

--- a/lib/sequentia/models/base.py
+++ b/lib/sequentia/models/base.py
@@ -8,6 +8,7 @@ from sklearn.metrics import accuracy_score, r2_score
 from sequentia.utils.validation import Array
 from sequentia.utils.decorators import _requires_fit
 
+
 class _Classifier(BaseEstimator, ClassifierMixin):
     def fit(
         self,
@@ -17,12 +18,23 @@ class _Classifier(BaseEstimator, ClassifierMixin):
     ) -> _Classifier:
         raise NotImplementedError
 
+
     def predict(
         self,
         X: Array,
         lengths: Optional[Array[int]] = None
     ) -> Array[int]:
         raise NotImplementedError
+
+
+    def fit_predict(
+        self,
+        X: Array,
+        y: Array[int],
+        lengths: Optional[Array[int]] = None
+    ) -> Array[int]:
+        return self.fit(X, y, lengths).predict(X, lengths)
+
 
     def predict_proba(
         self,
@@ -31,12 +43,14 @@ class _Classifier(BaseEstimator, ClassifierMixin):
     ) -> Array[float]:
         raise NotImplementedError
 
+
     def predict_scores(
         self,
         X: Array,
         lengths: Optional[Array[int]] = None
     ) -> Array[float]:
         raise NotImplementedError
+
 
     @_requires_fit
     def score(
@@ -50,6 +64,7 @@ class _Classifier(BaseEstimator, ClassifierMixin):
         y_pred = self.predict(X, lengths)
         return accuracy_score(y, y_pred, normalize=normalize, sample_weight=sample_weight)
 
+
 class _Regressor(BaseEstimator, RegressorMixin):
     def fit(
         self,
@@ -59,12 +74,23 @@ class _Regressor(BaseEstimator, RegressorMixin):
     ) -> _Regressor:
         raise NotImplementedError
 
+
     def predict(
         self,
         X: Array[float],
         lengths: Optional[Array[int]] = None
     ) -> Array[float]:
         raise NotImplementedError
+
+
+    def fit_predict(
+        self,
+        X: Array[float],
+        y: Array[float],
+        lengths: Optional[Array[int]] = None
+    ) -> Array[float]:
+        return self.fit(X, y, lengths).predict(X, lengths)
+
 
     @_requires_fit
     def score(

--- a/lib/sequentia/models/hmm/classifier.py
+++ b/lib/sequentia/models/hmm/classifier.py
@@ -30,10 +30,12 @@ _defaults = SimpleNamespace(
     n_jobs=1,
 )
 
+
 class _HMMClassifierValidator(_Validator):
     prior: Optional[Union[Literal["frequency"], Dict[int, confloat(ge=0, le=1)]]] = _defaults.prior
     classes: Optional[Array[int]] = _defaults.classes
     n_jobs: Union[NegativeInt, PositiveInt] = _defaults.n_jobs
+
 
     @validator('prior')
     def check_prior(cls, value):
@@ -41,6 +43,7 @@ class _HMMClassifierValidator(_Validator):
             if not np.isclose(sum(value.values()), 1):
                 raise ValueError('Prior distribution must sum to one')
         return value
+
 
     @root_validator
     def check_prior_keys_with_classes(cls, values):
@@ -53,6 +56,7 @@ class _HMMClassifierValidator(_Validator):
                         'ensure that every label in `classes` is present in `prior`'
                     )
         return values
+
 
 class HMMClassifier(_Classifier):
     """A classifier consisting of HMMs, each trained independently to recognize sequences of a single class.
@@ -111,6 +115,7 @@ class HMMClassifier(_Classifier):
 
     _defaults = _defaults
 
+
     @_validate_params(using=_HMMClassifierValidator)
     def __init__(
         self,
@@ -149,17 +154,20 @@ class HMMClassifier(_Classifier):
         #: HMMs constituting the :class:`.HMMClassifier`.
         self.models = {}
 
+
     def add_model(
         self,
         model: _HMM,
         label: int
-    ):
+    ) -> HMMClassifier:
         """Adds a single HMM to the classifier.
 
         :param model: HMM to add to the classifier.
         :param label: Class represented by the HMM.
 
         :note: All models added to the classifier must be of the same type — either :class:`.GaussianMixtureHMM` or :class:`.CategoricalHMM`.
+
+        :return: The classifier.
         """
         if not isinstance(model, _HMM):
             raise TypeError('Expected `model` argument to be a type of HMM')
@@ -170,21 +178,27 @@ class HMMClassifier(_Classifier):
                     f'to this {type(self).__name__} instance'
                 )
         self.models[int(label)] = model
+        return self
+
 
     def add_models(
         self,
         models: Dict[int, _HMM]
-    ):
+    ) -> HMMClassifier:
         """Adds HMMs to the classifier.
 
         :param models: HMMs to add to the classifier. The key for each HMM should be the label of the class represented by the HMM.
 
         :note: All models added to the classifier must be of the same type — either :class:`.GaussianMixtureHMM` or :class:`.CategoricalHMM`.
+
+        :return: The classifier.
         """
         if not all(isinstance(model, _HMM) for model in models.values()):
             raise TypeError('Expected all provided `models` to be a type of HMM')
         for label, model in models.items():
             self.add_model(model, label)
+        return self
+
 
     def fit(
         self,
@@ -271,6 +285,7 @@ class HMMClassifier(_Classifier):
 
         return self
 
+
     @_requires_fit
     def predict(
         self,
@@ -298,6 +313,34 @@ class HMMClassifier(_Classifier):
         scores = self.predict_scores(X, lengths)
         max_score_idxs = scores.argmax(axis=1)
         return self.classes_[max_score_idxs]
+
+
+    def fit_predict(
+        self,
+        X: Array,
+        y: Array[int],
+        lengths: Optional[Array[int]] = None
+    ) -> Array[int]:
+        """Fits the classifier to the sequence(s) in ``X`` and predicts classes for ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D array if :class:`.CategoricalHMM` is being used, or either a 1D or 2D array if :class:`.GaussianMixtureHMM` is being used.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param y: Classes corresponding to sequence(s) provided in ``X``.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: Class predictions.
+        """
+        return super().fit_predict(X, y, lengths)
+
 
     @_requires_fit
     def predict_proba(
@@ -330,6 +373,7 @@ class HMMClassifier(_Classifier):
         proba = np.exp(proba)
         proba /= proba.sum(axis=1, keepdims=True)
         return proba
+
 
     @_requires_fit
     def predict_scores(
@@ -367,6 +411,7 @@ class HMMClassifier(_Classifier):
             )
         )
 
+
     @_requires_fit
     def score(
         self,
@@ -402,16 +447,19 @@ class HMMClassifier(_Classifier):
         """
         return super().score(X, y, lengths, normalize, sample_weight)
 
+
     @_validate_params(using=_HMMClassifierValidator)
     @_override_params(_HMMClassifierValidator.fields(), temporary=False)
     def set_params(self, **kwargs) -> HMMClassifier:
         return self
+
 
     def _compute_scores_chunk(self, idxs, X):
         scores = np.zeros((len(idxs), len(self.classes_)))
         for i, x in enumerate(SequentialDataset._iter_X(X, idxs)):
             scores[i] = self._compute_log_posterior(x)
         return scores
+
 
     def _compute_log_posterior(self, x):
         log_posterior = np.full(len(self.classes_), -np.inf)
@@ -422,13 +470,16 @@ class HMMClassifier(_Classifier):
             log_posterior[i] = log_prior + log_likelihood
         return log_posterior
 
+
     def _base_sequence_validator(self, **kwargs):
         model = self.models[0]
         return model._base_sequence_validator(**kwargs)
 
+
     def _sequence_classifier_validator(self, **kwargs):
         model = self.models[0]
         return model._sequence_classifier_validator(**kwargs)
+
 
     @_requires_fit
     def save(self, path: Union[str, pathlib.Path, IO]):
@@ -452,6 +503,7 @@ class HMMClassifier(_Classifier):
 
         # Serialize model
         joblib.dump(state, path)
+
 
     @classmethod
     def load(cls, path: Union[str, pathlib.Path, IO]) -> HMMClassifier:

--- a/lib/sequentia/models/hmm/classifier.py
+++ b/lib/sequentia/models/hmm/classifier.py
@@ -405,7 +405,7 @@ class HMMClassifier(_Classifier):
         n_jobs = _effective_n_jobs(self.n_jobs, data.lengths)
         chunk_idxs = np.array_split(SequentialDataset._get_idxs(data.lengths), n_jobs)
         return np.concatenate(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._compute_scores_chunk)(idxs, data.X)
                 for idxs in chunk_idxs
             )

--- a/lib/sequentia/models/knn/base.py
+++ b/lib/sequentia/models/knn/base.py
@@ -46,6 +46,7 @@ _defaults = SimpleNamespace(
     random_state=None,
 )
 
+
 class _KNNValidator(_Validator):
     k: PositiveInt = _defaults.k
     weighting: Optional[Callable] = _defaults.weighting
@@ -55,6 +56,7 @@ class _KNNValidator(_Validator):
     n_jobs: Union[NegativeInt, PositiveInt] = _defaults.n_jobs
     random_state: Optional[Union[NonNegativeInt, np.random.RandomState]] = _defaults.random_state
 
+
     @validator('use_c')
     def check_use_c(cls, value):
         use_c = value
@@ -63,12 +65,15 @@ class _KNNValidator(_Validator):
             use_c = False
         return use_c
 
+
     @validator('random_state')
     def check_random_state(cls, value):
         return check_random_state(value)
 
+
 class _KNNMixin:
     _defaults = _defaults
+
 
     @_requires_fit
     @_override_params(['k', 'window', 'independent'])
@@ -112,7 +117,6 @@ class _KNNMixin:
             - DTW distances of the k-nearest training sequences.
             - Corresponding outputs of the k-nearest training sequences.
         """
-
         distances = self.compute_distance_matrix(X, lengths)
         partition_by = range(self.k) if sort else self.k
         k_idxs = np.argpartition(distances, partition_by, axis=1)[:, :self.k]
@@ -153,7 +157,6 @@ class _KNNMixin:
 
         :return: DTW distance matrix.
         """
-
         data = _BaseMultivariateFloatSequenceValidator(X=X, lengths=lengths)
 
         n_jobs = _effective_n_jobs(self.n_jobs, data.lengths)
@@ -187,7 +190,6 @@ class _KNNMixin:
 
         :return: DTW distance.
         """
-
         A = _SingleMultivariateFloatSequenceValidator(sequence=A).sequence
         B = _SingleMultivariateFloatSequenceValidator(sequence=B).sequence
         return self._dtw(A, B)
@@ -216,7 +218,6 @@ class _KNNMixin:
 
         :return: Plot axes.
         """
-
         from dtaidistance import dtw_visualisation
 
         a = _SingleUnivariateFloatSequenceValidator(sequence=a).sequence
@@ -265,7 +266,6 @@ class _KNNMixin:
 
         :return: Plot axes.
         """
-
         import matplotlib.pyplot as plt
 
         distances = self.compute_distance_matrix(X, lengths)
@@ -313,7 +313,6 @@ class _KNNMixin:
 
         :return: Plot axes.
         """
-
         import matplotlib.pyplot as plt
 
         distances = self.compute_distance_matrix(X, lengths)

--- a/lib/sequentia/models/knn/base.py
+++ b/lib/sequentia/models/knn/base.py
@@ -166,7 +166,7 @@ class _KNNMixin:
         col_chunk_idxs = np.array_split(self.idxs_, n_jobs)
 
         return np.vstack(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._distance_matrix_row_chunk)(
                     row_idxs, col_chunk_idxs, data.X, n_jobs, dtw_
                 ) for row_idxs in row_chunk_idxs
@@ -371,7 +371,7 @@ class _KNNMixin:
         TODO
         """
         return np.hstack(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._distance_matrix_row_col_chunk)(
                     col_idxs, row_idxs, X, dist
                 ) for col_idxs in col_chunk_idxs

--- a/lib/sequentia/models/knn/classifier.py
+++ b/lib/sequentia/models/knn/classifier.py
@@ -354,7 +354,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         n_jobs = _effective_n_jobs(self.n_jobs, scores)
         score_chunks = np.array_split(scores, n_jobs)
         return np.concatenate(
-            Parallel(n_jobs=n_jobs)(
+            Parallel(n_jobs=n_jobs, max_nbytes=None)(
                 delayed(self._find_max_labels_chunk)(score_chunk)
                 for score_chunk in score_chunks
             )

--- a/lib/sequentia/models/knn/classifier.py
+++ b/lib/sequentia/models/knn/classifier.py
@@ -30,8 +30,10 @@ _defaults = SimpleNamespace(
     }
 )
 
+
 class _KNNClassifierValidator(_KNNValidator):
     classes: Optional[Array[int]] = _defaults.classes
+
 
 class KNNClassifier(_KNNMixin, _Classifier):
     """A k-nearest neighbor classifier that uses DTW as a distance measure for sequence comparison.
@@ -67,6 +69,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
     """
 
     _defaults = _defaults
+
 
     @_validate_params(using=_KNNClassifierValidator)
     def __init__(
@@ -132,6 +135,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         #: Seed or :class:`numpy:numpy.random.RandomState` object for reproducible pseudo-randomness.
         self.random_state = random_state
 
+
     def fit(
         self,
         X: Array[float],
@@ -165,6 +169,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         self.classes_ = _check_classes(data.y, self.classes)
         return self
 
+
     @_requires_fit
     def predict(
         self,
@@ -191,6 +196,34 @@ class KNNClassifier(_KNNMixin, _Classifier):
         """
         class_scores = self.predict_scores(X, lengths)
         return self._find_max_labels(class_scores)
+
+
+    def fit_predict(
+        self,
+        X: Array[float],
+        y: Array[int],
+        lengths: Optional[Array[int]] = None
+    ) -> Array[int]:
+        """Fits the classifier to the sequence(s) in ``X`` and predicts classes for ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param y: Classes corresponding to sequence(s) provided in ``X``.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: Class predictions.
+        """
+        return super().fit_predict(X, y, lengths)
+
 
     @_requires_fit
     def predict_proba(
@@ -221,6 +254,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         class_scores = self.predict_scores(X, lengths)
         return class_scores / class_scores.sum(axis=1, keepdims=True)
 
+
     @_requires_fit
     def predict_scores(
         self,
@@ -250,6 +284,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         _, k_distances, k_labels = self.query_neighbors(X, lengths, sort=False)
         k_weightings = self._weighting()(k_distances)
         return self._compute_scores(k_labels, k_weightings)
+
 
     @_requires_fit
     def score(
@@ -286,10 +321,12 @@ class KNNClassifier(_KNNMixin, _Classifier):
         """
         return super().score(X, y, lengths, normalize, sample_weight)
 
+
     @_validate_params(using=_KNNValidator)
     @_override_params(_KNNValidator.fields(), temporary=False)
     def set_params(self, **kwargs):
         return self
+
 
     def _compute_scores(
         self,
@@ -304,6 +341,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
         for i, k in enumerate(self.classes_):
             scores[:, i] = np.einsum('ij,ij->i', labels == k, weightings)
         return scores
+
 
     def _find_max_labels(
         self,
@@ -322,6 +360,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
             )
         )
 
+
     def _find_max_labels_chunk(
         self,
         score_chunk: Array[float]
@@ -335,6 +374,7 @@ class KNNClassifier(_KNNMixin, _Classifier):
             max_score_idxs = self._multi_argmax(scores)
             max_labels[i] = self.random_state_.choice(self.classes_[max_score_idxs], size=1)
         return max_labels
+
 
     @staticmethod
     @njit

--- a/lib/sequentia/models/knn/regressor.py
+++ b/lib/sequentia/models/knn/regressor.py
@@ -18,6 +18,7 @@ from sequentia.utils.validation import (
 
 __all__ = ['KNNRegressor']
 
+
 class KNNRegressor(_KNNMixin, _Regressor):
     """A k-nearest neighbor regressor that uses DTW as a distance measure for sequence comparison.
 
@@ -79,6 +80,7 @@ class KNNRegressor(_KNNMixin, _Regressor):
         #: Seed or :class:`numpy:numpy.random.RandomState` object for reproducible pseudo-randomness.
         self.random_state = random_state
 
+
     def fit(
         self,
         X: Array[float],
@@ -111,6 +113,7 @@ class KNNRegressor(_KNNMixin, _Regressor):
         self.random_state_ = check_random_state(self.random_state)
         return self
 
+
     @_requires_fit
     def predict(
         self,
@@ -138,6 +141,34 @@ class KNNRegressor(_KNNMixin, _Regressor):
         _, k_distances, k_outputs = self.query_neighbors(X, lengths, sort=False)
         k_weightings = self._weighting()(k_distances)
         return (k_outputs * k_weightings).sum(axis=1) / k_weightings.sum(axis=1)
+
+
+    def fit_predict(
+        self,
+        X: Array[float],
+        y: Array[float],
+        lengths: Optional[Array[int]] = None
+    ) -> Array[float]:
+        """Fits the regressor to the sequence(s) in ``X`` and predicts outputs for ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param y: Outputs corresponding to sequence(s) provided in ``X``.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: Output predictions.
+        """
+        return super().fit_predict(X, y, lengths)
+
 
     @_requires_fit
     def score(
@@ -170,6 +201,7 @@ class KNNRegressor(_KNNMixin, _Regressor):
         :return: Coefficient of determination.
         """
         return super().score(X, y, lengths, sample_weight)
+
 
     @_validate_params(using=_KNNValidator)
     @_override_params(['k', 'weighting', 'window', 'independent', 'use_c', 'n_jobs'], temporary=False)

--- a/lib/sequentia/pipeline.py
+++ b/lib/sequentia/pipeline.py
@@ -1,0 +1,594 @@
+"""
+Pipeline is an adapted version of Pipeline from the sklearn.pipeline module,
+and largely relies on its source code.
+
+Below is the original license from Scikit-Learn, copied on 31st December 2022
+from https://github.com/scikit-learn/scikit-learn/blob/main/COPYING.
+
+---
+
+BSD 3-Clause License
+
+Copyright (c) 2007-2022 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Any, Union, List, Tuple
+
+import sklearn.pipeline
+import sklearn.base
+from joblib import Memory
+
+from sklearn.pipeline import _final_estimator_has
+from sklearn.utils.metaestimators import available_if
+from sklearn.utils import _print_elapsed_time
+from sklearn.utils.validation import check_memory
+from sklearn.base import BaseEstimator, ClassifierMixin, TransformerMixin, clone
+
+from sequentia.preprocessing.base import Transform
+from sequentia.utils.validation import Array
+
+__all__ = ["Pipeline"]
+
+
+class Pipeline(sklearn.pipeline.Pipeline):
+    """Pipeline of transforms with a final estimator.
+
+    Sequentially apply a list of transforms and a final estimator.
+    Intermediate steps of the pipeline must be 'transforms', that is, they
+    must implement ``fit`` and ``transform`` methods.
+    The final estimator only needs to implement ``fit``.
+    The transformers in the pipeline can be cached using ``memory`` argument.
+    The purpose of the pipeline is to assemble several steps that can be
+    cross-validated together while setting different parameters. For this, it
+    enables setting parameters of the various steps using their names and the
+    parameter name separated by a ``__``. A step's estimator may be replaced
+    entirely by setting the parameter with its name to another estimator,
+    or a transformer removed by setting it to ``'passthrough'`` or ``None``.
+
+    See Also
+    --------
+    :class:`sklearn.pipeline.Pipeline`:
+        :class:`.Pipeline` is based on :class:`sklearn.pipeline.Pipeline`,
+        but adapted to accept and work with sequences.
+
+        Read more in the :ref:`User Guide <pipeline>`.
+
+    Examples
+    --------
+    Creating a :class:`.Pipeline` consisting of two transforms and a :class:`.KNNClassifier`,
+    and fitting it to sequences in the spoken digits dataset. ::
+
+        from sequentia.models import KNNClassifier
+        from sequentia.preprocessing import IndependentFunctionTransformer
+        from sequentia.pipeline import Pipeline
+        from sequentia.datasets import load_digits
+
+        from sklearn.preprocessing import scale
+        from sklearn.decomposition import PCA
+
+        # Fetch MFCCs of spoken digits
+        digits = load_digits()
+        train, test = digits.split(test_size=0.2)
+
+        # Create a pipeline with two transforms and a classifier
+        pipeline = Pipeline([
+            ('standardize', IndependentFunctionTransformer(scale)),
+            ('pca', PCA(n_components=5)),
+            ('clf', KNNClassifier(k=1))
+        ])
+
+        # Fit the pipeline transforms and classifier to training data
+        pipeline.fit(train.X, train.lengths)
+
+        # Apply the transforms to training sequences and make predictions
+        y_train_pred = pipeline.predict(train.X, train.y, train.lengths)
+
+        # Calculate accuracy on test data
+        acc = pipeline.score(test.X, test.y, test.lengths)
+    """
+
+    def __init__(
+        self,
+        steps: List[Tuple[str, BaseEstimator]],
+        *,
+        memory: Optional[Union[str, Memory]] = None,
+        verbose: bool = False
+    ) -> Pipeline:
+        """Initializes the :class:`.Pipeline`.
+
+        :param steps: Collection of transforms implementing ``fit``/``transform`` that are chained,
+            with the last object being an estimator.
+
+        :param memory: Used to cache the fitted transformers of the pipeline. By default,
+            no caching is performed. If a string is given, it is the path to
+            the caching directory. Enabling caching triggers a clone of
+            the transformers before fitting. Therefore, the transformer
+            instance given to the pipeline cannot be inspected
+            directly. Use the attribute ``named_steps`` or ``steps`` to
+            inspect estimators within the pipeline. Caching the
+            transformers is advantageous when fitting is time consuming.
+
+        :param verbose: If ``True``, the time elapsed while fitting each step will be printed as it
+            is completed.
+        """
+        super().__init__(steps, memory=memory, verbose=verbose)
+
+
+    def _can_transform(self):
+        return self._final_estimator == "passthrough" or hasattr(
+            self._final_estimator, "transform"
+        )
+
+
+    def _can_inverse_transform(self):
+        return all(hasattr(t, "inverse_transform") for _, _, t in self._iter())
+
+
+    def _fit(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None,
+        **fit_params_steps
+    ) -> Array:
+        # shallow copy of steps - this should really be steps_
+        self.steps = list(self.steps)
+        self._validate_steps()
+        # Setup the memory
+        memory = check_memory(self.memory)
+
+        fit_transform_one_cached = memory.cache(_fit_transform_one)
+
+        for step_idx, name, transformer in self._iter(
+            with_final=False, filter_passthrough=False
+        ):
+            if transformer is None or transformer == "passthrough":
+                with _print_elapsed_time("Pipeline", self._log_message(step_idx)):
+                    continue
+
+            if hasattr(memory, "location") and memory.location is None:
+                # we do not clone when caching is disabled to
+                # preserve backward compatibility
+                cloned_transformer = transformer
+            else:
+                cloned_transformer = clone(transformer)
+            # Fit or load from cache the current transformer
+            X, fitted_transformer = fit_transform_one_cached(
+                cloned_transformer,
+                X,
+                lengths,
+                None,
+                message_clsname="Pipeline",
+                message=self._log_message(step_idx),
+                **fit_params_steps[name],
+            )
+            # Replace the transformer of the step with the fitted
+            # transformer. This is necessary when loading the transformer
+            # from the cache.
+            self.steps[step_idx] = (name, fitted_transformer)
+        return X
+
+
+    def fit(
+        self,
+        X: Array,
+        y: Optional[Array] = None,
+        lengths: Optional[Array] = None,
+        **fit_params
+    ) -> Pipeline:
+        """Fit the model.
+
+        Fit all the transformers one after the other and transform the
+        data. Finally, fit the transformed data using the final estimator.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param y: Outputs corresponding to sequence(s) provided in ``X``.
+            Only required if the final estimator is a supervised model.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :param fit_params: Parameters passed to the ``fit`` method of each step,
+            where each parameter name is prefixed such that parameter ``p`` for step ``s`` has key ``s__p``.
+
+        :return: The fitted pipeline.
+        """
+        fit_params_steps = self._check_fit_params(**fit_params)
+        Xt = self._fit(X, lengths, **fit_params_steps)
+
+        with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):
+            if self._final_estimator != "passthrough":
+                fit_params_last_step = fit_params_steps[self.steps[-1][0]]
+                if isinstance(self._final_estimator, ClassifierMixin):
+                    self._final_estimator.fit(Xt, y, lengths, **fit_params_last_step)
+                else:
+                    self._final_estimator.fit(Xt, lengths, **fit_params_last_step)
+        return self
+
+
+    def fit_transform(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None,
+        **fit_params
+    ) -> Array:
+        """Fit the model and transform with the final estimator.
+
+        Fits all the transformers one after the other and transform the
+        data. Then uses `fit_transform` on transformed data with the final
+        estimator.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :param fit_params: Parameters passed to the ``fit`` method of each step,
+            where each parameter name is prefixed such that parameter ``p`` for step ``s`` has key ``s__p``.
+
+        :return: The transformed data.
+        """
+        fit_params_steps = self._check_fit_params(**fit_params)
+        Xt = self._fit(X, lengths, **fit_params_steps)
+
+        last_step = self._final_estimator
+        with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):
+            if last_step == "passthrough":
+                return Xt
+            fit_params_last_step = fit_params_steps[self.steps[-1][0]]
+
+            if is_sequentia_transform := isinstance(last_step, Transform):
+                fit_params_last_step["lengths"] = lengths
+
+            if hasattr(last_step, "fit_transform"):
+                return last_step.fit_transform(Xt, **fit_params_last_step)
+            else:
+                transform_params = {}
+                if is_sequentia_transform:
+                    transform_params["lengths"] = lengths
+                getattr(last_step, "transform")
+                return last_step.fit(Xt, **fit_params_last_step).transform(Xt, **transform_params)
+
+
+    @available_if(_final_estimator_has("predict"))
+    def predict(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> Array:
+        """Transform the data, and apply `predict` with the final estimator.
+
+        Call `transform` of each transformer in the pipeline. The transformed
+        data are finally passed to the final estimator that calls `predict`
+        method. Only valid if the final estimator implements `predict`.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: Output predictions.
+        """
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            transform_params = {}
+            if isinstance(transform, Transform):
+                transform_params["lengths"] = lengths
+            Xt = transform.transform(Xt, **transform_params)
+        return self.steps[-1][1].predict(Xt, lengths)
+
+
+    @available_if(_final_estimator_has("fit_predict"))
+    def fit_predict(
+        self,
+        X: Array,
+        y: Array,
+        lengths: Optional[Array] = None,
+        **fit_params
+    ) -> Array:
+        """Transform the data, and apply `fit_predict` with the final estimator.
+
+        Call `fit_transform` of each transformer in the pipeline. The
+        transformed data are finally passed to the final estimator that calls
+        `fit_predict` method. Only valid if the final estimator implements
+        `fit_predict`.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param y: Outputs corresponding to sequence(s) provided in ``X``.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :param fit_params: Parameters passed to the ``fit`` method of each step,
+            where each parameter name is prefixed such that parameter ``p`` for step ``s`` has key ``s__p``.
+
+        :return: Output predictions.
+        """
+        fit_params_steps = self._check_fit_params(**fit_params)
+        Xt = self._fit(X, lengths, **fit_params_steps)
+
+        fit_params_last_step = fit_params_steps[self.steps[-1][0]]
+        with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):
+            y_pred = self.steps[-1][1].fit_predict(Xt, y, lengths, **fit_params_last_step)
+        return y_pred
+
+
+    @available_if(_final_estimator_has("predict_proba"))
+    def predict_proba(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> Array:
+        """Transform the data, and apply `predict_proba` with the final estimator.
+
+        Call `transform` of each transformer in the pipeline. The transformed
+        data are finally passed to the final estimator that calls
+        `predict_proba` method. Only valid if the final estimator implements
+        `predict_proba`.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: Output probabilities.
+        """
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            transform_params = {}
+            if isinstance(transform, Transform):
+                transform_params["lengths"] = lengths
+            Xt = transform.transform(Xt, **transform_params)
+        return self.steps[-1][1].predict_proba(Xt, lengths)
+
+
+    @available_if(_can_transform)
+    def transform(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> Array:
+        """Transform the data, and apply `transform` with the final estimator.
+
+        Call `transform` of each transformer in the pipeline. The transformed
+        data are finally passed to the final estimator that calls
+        `transform` method. Only valid if the final estimator
+        implements `transform`.
+
+        This also works where final estimator is `None` in which case all prior
+        transformations are applied.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: The transformed data.
+        """
+        Xt = X
+        for _, _, transform in self._iter():
+            transform_params = {}
+            if isinstance(transform, Transform):
+                transform_params["lengths"] = lengths
+            Xt = transform.transform(Xt, **transform_params)
+        return Xt
+
+
+    @available_if(_can_inverse_transform)
+    def inverse_transform(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> Array:
+        """Apply `inverse_transform` for each step in a reverse order.
+
+        All estimators in the pipeline must support `inverse_transform`.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: The inverse transformed data.
+        """
+        reverse_iter = reversed(list(self._iter()))
+        for _, _, transform in reverse_iter:
+            transform_params = {}
+            if isinstance(transform, Transform):
+                transform_params["lengths"] = lengths
+            X = transform.inverse_transform(X, **transform_params)
+        return X
+
+
+    @available_if(_final_estimator_has("score"))
+    def score(
+        self,
+        X: Array,
+        y: Optional[Array] = None,
+        lengths: Optional[Array] = None,
+        sample_weight: Optional[Any] = None
+    ) -> float:
+        """Transform the data, and apply `score` with the final estimator.
+
+        Call `transform` of each transformer in the pipeline. The transformed
+        data are finally passed to the final estimator that calls
+        `score` method. Only valid if the final estimator implements `score`.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param y: Outputs corresponding to sequence(s) provided in ``X``.
+            Must be provided if the final estimator is a model, i.e. not a transform.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :param sample_weight: If not ``None``, this argument is passed as ``sample_weight``
+            keyword argument to the ``score`` method of the final estimator.
+
+        :return: Result of calling `score` on the final estimator.
+        """
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            transform_params = {}
+            if isinstance(transform, Transform):
+                transform_params["lengths"] = lengths
+            Xt = transform.transform(Xt, **transform_params)
+
+        score_params = {}
+        if sample_weight is not None:
+            score_params["sample_weight"] = sample_weight
+
+        last_step = self.steps[-1][1]
+        if isinstance(last_step, TransformerMixin):
+            return last_step.score(Xt, lengths, **score_params)
+        else:
+            return last_step.score(Xt, y, lengths, **score_params)
+
+
+def _fit_transform_one(
+    transformer,
+    X,
+    lengths,
+    weight,
+    message_clsname="",
+    message=None,
+    **fit_params
+):
+    with _print_elapsed_time(message_clsname, message):
+        if is_sequentia_transformer := isinstance(transformer, Transform):
+            fit_params["lengths"] = lengths
+        if hasattr(transformer, "fit_transform"):
+            res = transformer.fit_transform(X, **fit_params)
+        else:
+            transform_params = {}
+            if is_sequentia_transformer:
+                transform_params["lengths"] = lengths
+            res = transformer.fit(X, **fit_params).transform(X, **transform_params)
+
+    if weight is None:
+        return res, transformer
+    return res * weight, transformer
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    from sequentia.models import KNNClassifier, HMMClassifier, GaussianMixtureHMM
+    from sequentia.datasets import load_digits
+    from sequentia.preprocessing import IndependentFunctionTransformer
+    # try normal FunctionTransformer
+
+    from sklearn.preprocessing import StandardScaler, scale
+    from sklearn.decomposition import PCA
+
+    random_state = np.random.RandomState(0)
+
+    # digits = load_digits(digits=[0, 1])
+    digits = load_digits()
+    # subset, _ = digits.split(train_size=0.1, stratify=True, random_state=random_state)
+    # train, test = subset.split(test_size=0.2)
+    train, test = digits.split(test_size=0.2)
+
+    pipeline = Pipeline([
+        ('standardize', IndependentFunctionTransformer(scale)),
+        ('pca', PCA(n_components=5, random_state=random_state)),
+        ('clf', HMMClassifier(n_jobs=-1).add_models({
+            k: GaussianMixtureHMM(random_state=random_state)
+            for k in train.classes
+        }))
+        # ('clf', KNNClassifier(k=1, use_c=True, n_jobs=-1, random_state=random_state))
+    ])
+
+    # Xt = pipeline.fit_transform(*train.X_lengths)
+
+    y_pred = pipeline.fit_predict(*train.X_y_lengths)
+
+    breakpoint()
+
+    # from scipy.signal import medfilt2d, convolve
+    # ('median_filter', IndependentFunctionTransformer(medfilt2d, kw_args={"kernel_size": (5, 1)}))

--- a/lib/sequentia/preprocessing/base.py
+++ b/lib/sequentia/preprocessing/base.py
@@ -1,6 +1,32 @@
-from sklearn.base import TransformerMixin
+from typing import Optional
+
+from sklearn.base import TransformerMixin, BaseEstimator
+
+from sequentia.utils.validation import Array
 
 __all__ = ['Transform']
 
-class Transform(TransformerMixin):
-    pass
+
+class Transform(TransformerMixin, BaseEstimator):
+    def fit_transform(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None,
+    ) -> Array:
+        """Fits the transformer to the sequence(s) in ``X`` and returns a transformed version of ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: The transformed data.
+        """
+        return self.fit(X, lengths).transform(X, lengths)

--- a/lib/sequentia/preprocessing/transforms.py
+++ b/lib/sequentia/preprocessing/transforms.py
@@ -1,1 +1,350 @@
-from .base import Transform
+"""
+IndependentFunctionTransformer is an adapted version of FunctionTransformer
+from the sklearn.preprocessing module, and largely relies on its source code.
+
+Below is the original license from Scikit-Learn, copied on 31st December 2022
+from https://github.com/scikit-learn/scikit-learn/blob/main/COPYING.
+
+---
+
+BSD 3-Clause License
+
+Copyright (c) 2007-2022 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Callable, Optional, Dict, Any
+
+import numpy as np
+from pydantic import PositiveInt
+from sklearn.utils.validation import _allclose_dense_sparse, check_array
+from scipy.signal import medfilt2d, convolve
+
+from sequentia.preprocessing.base import Transform
+from sequentia.utils.validation import _BaseSequenceValidator, Array
+from sequentia.utils.data import SequentialDataset
+
+__all__ = ["IndependentFunctionTransformer", "mean_filter", "median_filter"]
+
+
+class IndependentFunctionTransformer(Transform):
+    """Constructs a transformer from an arbitrary callable,
+    applying the transform independently to each sequence.
+
+    This transform forwards its ``X`` and ``lengths`` arguments
+    to a user-defined function or function object and returns the result of this
+    function. This is useful for stateless transformations such as taking the
+    log of frequencies, doing custom scaling, etc.
+    Note: If a lambda is used as the function, then the resulting
+    transformer will not be pickleable.
+
+    This works conveniently with functions in :mod:`sklearn.preprocessing`
+    such as :func:`~sklearn.preprocessing.scale` or :func:`~sklearn.preprocessing.normalize`.
+
+    :note: This is a stateless transform, meaning :func:`fit` and :func:`fit_transform` will not fit on any data.
+
+    See Also
+    --------
+    :class:`sklearn.preprocessing.FunctionTransformer`
+        :class:`.IndependentFunctionTransformer` is based on this class,
+        which applies the callable to the entire input array ``X`` as if it were a single sequence.
+        Read more in the :ref:`User Guide <function_transformer>`.
+
+    Examples
+    --------
+    Using an :class:`IndependentFunctionTransformer` with :func:`sklearn.preprocessing.minmax_scale` to
+    scale features to the range [0, 1] independently for each sequence in the spoken digits dataset. ::
+
+        from sklearn.preprocessing import minmax_scale
+        from sequentia.preprocessing import IndependentFunctionTransformer
+        from sequentia.datasets import load_digits
+
+        # Fetch MFCCs of spoken digits
+        data = load_digits()
+
+        # Create an independent min-max transform
+        transform = IndependentFunctionTransformer(minmax_scale)
+
+        # Apply the transform to the data
+        Xt = transform.transform(data.X, data.lengths)
+    """
+
+    _parameter_constraints: dict = {
+        "func": [callable, None],
+        "inverse_func": [callable, None],
+        "validate": ["boolean"],
+        "check_inverse": ["boolean"],
+        "kw_args": [dict, None],
+        "inv_kw_args": [dict, None],
+    }
+
+    def __init__(
+        self,
+        func: Optional[Callable] = None,
+        inverse_func: Optional[Callable] = None,
+        *,
+        validate: bool = False,
+        check_inverse: bool = True,
+        kw_args =None,
+        inv_kw_args=None,
+    ) -> IndependentFunctionTransformer:
+        """Initializes the :class:`.IndependentFunctionTransformer`.
+
+        :param func: The callable to use for the transformation.
+            This will be passed the same arguments as transform, with args and kwargs forwarded.
+            If ``None``, then ``func`` will be the identity function.
+
+        :param inverse_func: The callable to use for the inverse transformation.
+            This will be passed the same arguments as inverse transform, with args and kwargs forwarded.
+            If ``None``, then ``inverse_func`` will be the identity function.
+
+        :param validate: Indicates whether the input ``X`` array should be checked before calling ``func``.
+
+            - If ``False``, there is no input validation.
+            - If ``True``, then ``X`` will be converted to a 2-dimensional NumPy array.
+              If the conversion is not possible an exception is raised.
+
+        :param check_inverse: Whether to check that or ``func`` followed by ``inverse_func`` leads to the original inputs.
+            It can be used for a sanity check, raising a warning when the condition is not fulfilled.
+
+        :param kw_args: Dictionary of additional keyword arguments to pass to ``func``.
+
+        :param inv_kw_args: Dictionary of additional keyword arguments to pass to ``inverse_func``.
+        """
+        self.func = func
+        self.inverse_func = inverse_func
+        self.validate = validate
+        self.check_inverse = check_inverse
+        self.kw_args: Optional[Dict[str, Any]] = kw_args
+        self.inv_kw_args: Optional[Dict[str, Any]] = inv_kw_args
+
+    def _check_input(self, X, lengths, *, reset):
+        data = _BaseSequenceValidator(X=X, lengths=lengths)
+        X, lengths = data.X, data.lengths
+        if self.validate:
+            X = self._validate_data(X, reset=reset)
+            return X, lengths
+        elif reset:
+            # Set feature_names_in_ and n_features_in_ even if validate=False
+            # We run this only when reset==True to store the attributes but not
+            # validate them, because validate=False
+            self._check_n_features(X, reset=reset)
+            self._check_feature_names(X, reset=reset)
+        return X, lengths
+
+    def _check_inverse_transform(self, X, lengths):
+        """Check that func and inverse_func are the inverse."""
+        idx_selected = slice(None, None, max(1, X.shape[0] // 100))
+        X_round_trip = self.inverse_transform(self.transform(X[idx_selected], lengths), lengths)
+
+        if not np.issubdtype(X.dtype, np.number):
+            raise ValueError(
+                "'check_inverse' is only supported when all the elements in `X` are numerical."
+            )
+
+        if not _allclose_dense_sparse(X[idx_selected], X_round_trip):
+            warnings.warn(
+                "The provided functions are not strictly"
+                " inverse of each other. If you are sure you"
+                " want to proceed regardless, set"
+                " 'check_inverse=False'.",
+                UserWarning,
+            )
+
+    def fit(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> IndependentFunctionTransformer:
+        """Fits the transformer to ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: The fitted transformer.
+        """
+        self._validate_params()
+        X, lengths = self._check_input(X, lengths, reset=True)
+        if self.check_inverse and not (self.func is None or self.inverse_func is None):
+            self._check_inverse_transform(X, lengths)
+        return self
+
+    def transform(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> Array:
+        """Applies the transformation to ``X``, producing a transformed version of ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: The transformed array.
+        """
+        X, lengths = self._check_input(X, lengths, reset=False)
+        return self._transform(X, lengths, func=self.func, kw_args=self.kw_args)
+
+    def inverse_transform(
+        self,
+        X: Array,
+        lengths: Optional[Array] = None
+    ) -> Array:
+        """Applies the inverse transformation to ``X``.
+
+        :param X: Univariate or multivariate observation sequence(s).
+
+            - Should be a single 1D or 2D array.
+            - Should have length as the 1st dimension and features as the 2nd dimension.
+            - Should be a concatenated sequence if multiple sequences are provided,
+              with respective sequence lengths being provided in the ``lengths`` argument for decoding the original sequences.
+
+        :param lengths: Lengths of the observation sequence(s) provided in ``X``.
+
+            - If ``None``, then ``X`` is assumed to be a single observation sequence.
+            - ``len(X)`` should be equal to ``sum(lengths)``.
+
+        :return: The inverse transformed array.
+        """
+        data = _BaseSequenceValidator(X=X, lengths=lengths)
+        X, lengths = data.X, data.lengths
+        if self.validate:
+            X = check_array(X, accept_sparse=False)
+        return self._transform(X, lengths, func=self.inverse_func, kw_args=self.inv_kw_args)
+
+    def _transform(self, X, lengths, func=None, kw_args=None):
+        if func is None:
+            return X
+        apply = lambda x: func(x, **(kw_args if kw_args else {}))
+        idxs = SequentialDataset._get_idxs(lengths)
+        return np.vstack([apply(x) for x in SequentialDataset._iter_X(X, idxs)])
+
+    def __sklearn_is_fitted__(self):
+        """Return True since FunctionTransfomer is stateless."""
+        return True
+
+    def _more_tags(self):
+        return {"no_validation": not self.validate, "stateless": True}
+
+
+def mean_filter(x: Array, k: PositiveInt = 3) -> Array:
+    """Applies a mean filter of size ``k`` independently to each feature of the sequence,
+    retaining the original input shape by using appropriate padding.
+
+    This is implemented as a 1D convolution with a kernel of size ``k`` and values ``1 / k``.
+
+    :param x: Univariate or multivariate observation sequence.
+
+        - Should be a single 1D or 2D array.
+        - Should have length as the 1st dimension and features as the 2nd dimension.
+
+    :param k: Width of the filter.
+
+    :return: The filtered array.
+
+    Examples
+    --------
+    Applying a :func:`mean_filter` to a single sequence
+    and multiple sequences (independently via :class:`IndependentFunctionTransformer`) from the spoken digits dataset. ::
+
+        from sequentia.preprocessing import IndependentFunctionTransformer, mean_filter
+        from sequentia.datasets import load_digits
+
+        # Fetch MFCCs of spoken digits
+        data = load_digits()
+
+        # Apply the mean filter to the first sequence
+        x, _ = data[0]
+        xt = mean_filter(x, k=5)
+
+        # Create an independent mean filter transform
+        transform = IndependentFunctionTransformer(mean_filter, kw_args={"k": 5})
+
+        # Apply the transform to all sequences
+        Xt = transform.transform(data.X, data.lengths)
+    """
+    data = _BaseSequenceValidator(X=x)
+    return convolve(data.X, np.ones((k, 1)) / k, mode="same")
+
+
+def median_filter(x: Array, k: PositiveInt = 3) -> Array:
+    """Applies a median filter of size ``k`` independently to each feature of the sequence,
+    retaining the original input shape by using appropriate padding.
+
+    :param x: Univariate or multivariate observation sequence.
+
+        - Should be a single 1D or 2D array.
+        - Should have length as the 1st dimension and features as the 2nd dimension.
+
+    :param k: Width of the filter.
+
+    :return: The filtered array.
+
+    Examples
+    --------
+    Applying a :func:`median_filter` to a single sequence
+    and multiple sequences (independently via :class:`IndependentFunctionTransformer`) from the spoken digits dataset. ::
+
+        from sequentia.preprocessing import IndependentFunctionTransformer, median_filter
+        from sequentia.datasets import load_digits
+
+        # Fetch MFCCs of spoken digits
+        data = load_digits()
+
+        # Apply the median filter to the first sequence
+        x, _ = data[0]
+        xt = median_filter(x, k=5)
+
+        # Create an independent median filter transform
+        transform = IndependentFunctionTransformer(median_filter, kw_args={"k": 5})
+
+        # Apply the transform to all sequences
+        Xt = transform.transform(data.X, data.lengths)
+    """
+    data = _BaseSequenceValidator(X=x)
+    return medfilt2d(data.X, kernel_size=(k, 1))

--- a/lib/test/lib/preprocessing/test_transforms.py
+++ b/lib/test/lib/preprocessing/test_transforms.py
@@ -1,0 +1,69 @@
+import pytest
+
+import numpy as np
+
+from sklearn.preprocessing import minmax_scale
+
+from sequentia.datasets import load_digits
+from sequentia.preprocessing import transforms
+
+from sequentia.utils import SequentialDataset
+
+from ...support.assertions import assert_equal
+
+
+@pytest.fixture(scope='module')
+def random_state(request):
+    return np.random.RandomState(1)
+
+
+@pytest.fixture(scope='module')
+def data(random_state):
+    data_= load_digits(digits=[0])
+    _, subset = data_.split(test_size=0.2, random_state=random_state, stratify=True)
+    return subset
+
+
+def check_filter(x, xt, func, k):
+    """Only works for odd k"""
+    assert len(x) == len(xt)
+    assert_equal(xt[k // 2], func(x[:k], axis=0))
+
+
+def test_function_transformer(data):
+    # create the transform
+    transform = transforms.IndependentFunctionTransformer(minmax_scale)
+    # check that fit works - should do nothing
+    transform.fit(*data.X_lengths)
+    # check that fit_transform works - shouldn't do anything on fit, but should transform
+    X_fit_transform = transform.fit_transform(*data.X_lengths)
+    # check that transform works
+    X_transform = transform.transform(*data.X_lengths)
+    # check that fit_transform and transform produce the same transformed data
+    assert_equal(X_fit_transform, X_transform)
+    # check that features of each sequence are independently scaled to [0, 1]
+    for xt in SequentialDataset._iter_X(X_transform, data.idxs):
+        assert_equal(xt.min(axis=0), np.zeros(xt.shape[1]))
+        assert_equal(xt.max(axis=0), np.ones(xt.shape[1]))
+
+
+@pytest.mark.parametrize("avg", ["mean", "median"])
+@pytest.mark.parametrize("k", [3, 5])
+def test_filters(data, random_state, avg, k):
+    filter_ = getattr(transforms, f"{avg}_filter")
+    check_filter_ = lambda x, xt: check_filter(x, xt, getattr(np, avg), k)
+
+    # check that filters are correctly applied for a single sequence
+    n_features = 2
+    x = random_state.rand(10 * n_features).reshape(-1, n_features)
+    xt = filter_(x, k)
+    check_filter_(x, xt)
+
+    # create a transform using the filter, passing k
+    transform = transforms.IndependentFunctionTransformer(filter_, kw_args={"k": k})
+    Xt = transform.transform(data.X, data.lengths)
+
+    # check that filters are correctly applied for multiple sequences
+    idxs = SequentialDataset._get_idxs(data.lengths)
+    for x, xt in zip(*map(lambda X: SequentialDataset._iter_X(X, idxs), (data.X, Xt))):
+        check_filter_(x, xt)

--- a/lib/test/lib/test_pipeline.py
+++ b/lib/test/lib/test_pipeline.py
@@ -1,0 +1,212 @@
+import pytest
+
+import numpy as np
+from pydantic import ValidationError
+
+from sklearn.preprocessing import scale
+from sklearn.decomposition import PCA
+from sklearn.utils.validation import check_is_fitted
+from sklearn.exceptions import NotFittedError
+from sklearn.utils._param_validation import InvalidParameterError
+
+from sequentia.datasets import load_digits
+from sequentia.preprocessing import IndependentFunctionTransformer, mean_filter
+from sequentia.pipeline import Pipeline
+from sequentia.models import KNNClassifier
+
+from sequentia.utils import SequentialDataset
+
+from ..support.assertions import assert_equal, assert_not_equal
+
+
+@pytest.fixture(scope='module')
+def random_state(request):
+    return np.random.RandomState(0)
+
+
+@pytest.fixture(scope='module')
+def data(random_state):
+    data_= load_digits(digits=[0])
+    _, subset = data_.split(test_size=0.05, random_state=random_state, stratify=True)
+    return subset
+
+
+def test_pipeline_with_transforms(data):
+    # create pipeline with a stateless and stateful transform
+    pipeline = Pipeline([
+        ("scale", IndependentFunctionTransformer(
+            scale,
+            inverse_func=lambda x: x,
+            check_inverse=False
+        )),
+        ("pca", PCA(n_components=1)),
+    ])
+
+    # check that transforming without fitting doesn't work
+    with pytest.raises(NotFittedError):
+        pipeline.transform(*data.X_lengths)
+
+    # check that fitting without y works
+    check_is_fitted(pipeline.fit(*data.X_lengths))
+    for estimator in pipeline.named_steps.values():
+        check_is_fitted(estimator)
+
+    # check that fitting with y works
+    check_is_fitted(pipeline.fit(*data.X_y_lengths))
+    for estimator in pipeline.named_steps.values():
+        check_is_fitted(estimator)
+
+    # check that transforming after fit works
+    Xt = pipeline.transform(*data.X_lengths)
+    assert_not_equal(data.X, Xt)
+    assert Xt.shape == (len(data.X), 1)
+
+    # check that fit_transform works
+    Xt = pipeline.fit_transform(*data.X_lengths)
+    assert_not_equal(data.X, Xt)
+    assert Xt.shape == (len(data.X), 1)
+
+    # check that inverse_transform works
+    Xi = pipeline.inverse_transform(Xt, data.lengths)
+    assert_not_equal(Xt, Xi)
+
+    # check that prediction functions relying on X and lengths don't work
+    for func in ('predict', 'predict_proba'):
+        with pytest.raises(AttributeError):
+            getattr(pipeline, func)(*data.X_lengths)
+
+    # check that fit_predict doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.fit_predict(*data.X_y_lengths)
+
+    # check that score works if the final transform implements it, with y
+    pipeline.score(*data.X_y_lengths)
+
+    # check that score works if the final transform implements it, without y
+    pipeline.score(data.X, lengths=data.lengths)
+
+
+def test_pipeline_with_estimator(data):
+    pipeline = Pipeline([
+        ("knn", KNNClassifier(k=1)),
+    ])
+
+    # check that transforming doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.transform(*data.X_lengths)
+
+    # check that fitting without y doesn't work
+    with pytest.raises(ValidationError):
+        pipeline.fit(data.X, lengths=data.lengths)
+
+    # check that fitting with y works
+    check_is_fitted(pipeline.fit(*data.X_y_lengths))
+    for estimator in pipeline.named_steps.values():
+        check_is_fitted(estimator)
+
+    # check that transforming doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.transform(*data.X_lengths)
+
+    # check that fit_transform doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.fit_transform(*data.X_lengths)
+
+    # check that inverse_transform doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.inverse_transform(*data.X_lengths)
+
+    # check that predict works
+    y_pred = pipeline.predict(*data.X_lengths)
+    assert y_pred.shape == data.y.shape
+    assert set(y_pred) == set(data.classes)
+
+    # check that predict_proba works
+    proba_pred = pipeline.predict_proba(*data.X_lengths)
+    assert proba_pred.shape == (len(data), len(data.classes))
+
+    # check that fit_predict works
+    y_pred = pipeline.fit_predict(*data.X_y_lengths)
+    # check that all steps are fitted
+    check_is_fitted(pipeline.fit(*data.X_y_lengths))
+    for estimator in pipeline.named_steps.values():
+        check_is_fitted(estimator)
+    # check that predictions are valid
+    assert y_pred.shape == data.y.shape
+    assert set(y_pred) == set(data.classes)
+
+    # check that score with y works
+    pipeline.score(*data.X_y_lengths)
+
+    # check that score without y doesn't work
+    with pytest.raises(InvalidParameterError):
+        pipeline.score(data.X, lengths=data.lengths)
+
+
+def test_pipeline_with_transforms_and_estimator(data):
+    pipeline = Pipeline([
+        ("scale", IndependentFunctionTransformer(
+            scale,
+            inverse_func=lambda x: x,
+            check_inverse=False
+        )),
+        ("pca", PCA(n_components=1)),
+        ("knn", KNNClassifier(k=1)),
+    ])
+
+    # check that transforming doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.transform(*data.X_lengths)
+
+    # check that fitting without y doesn't work
+    with pytest.raises(ValidationError):
+        pipeline.fit(data.X, lengths=data.lengths)
+
+    # check that fitting with y works
+    check_is_fitted(pipeline.fit(*data.X_y_lengths))
+    for estimator in pipeline.named_steps.values():
+        check_is_fitted(estimator)
+    # check that X values were transformed
+    assert_not_equal(data.X, pipeline[-1].X_)
+    assert pipeline[-1].X_.shape == (len(data.X), 1)
+
+    # check that transforming doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.transform(*data.X_lengths)
+
+    # check that fit_transform doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.fit_transform(*data.X_lengths)
+
+    # check that inverse_transform doesn't work
+    with pytest.raises(AttributeError):
+        pipeline.inverse_transform(*data.X_lengths)
+
+    # check that predict works
+    y_pred = pipeline.predict(*data.X_lengths)
+    assert y_pred.shape == data.y.shape
+    assert set(y_pred) == set(data.classes)
+
+    # check that predict_proba works
+    proba_pred = pipeline.predict_proba(*data.X_lengths)
+    assert proba_pred.shape == (len(data), len(data.classes))
+
+    # check that fit_predict works
+    y_pred = pipeline.fit_predict(*data.X_y_lengths)
+    # check that all steps are fitted
+    check_is_fitted(pipeline.fit(*data.X_y_lengths))
+    for estimator in pipeline.named_steps.values():
+        check_is_fitted(estimator)
+    # check that predictions are valid
+    assert y_pred.shape == data.y.shape
+    assert set(y_pred) == set(data.classes)
+    # check that X values were transformed
+    assert_not_equal(data.X, pipeline[-1].X_)
+    assert pipeline[-1].X_.shape == (len(data.X), 1)
+
+    # check that score with y works
+    pipeline.score(*data.X_y_lengths)
+
+    # check that score without y doesn't work
+    with pytest.raises(InvalidParameterError):
+        pipeline.score(data.X, lengths=data.lengths)

--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,14 @@ setup(
     python_requires = '>=3.8',
     setup_requires = [
         'Cython>=0.28.5',
-        'numpy>=1.17',
+        'numpy>=1.18,<1.24',
         'scipy>=1.3',
     ],
     install_requires = [
         'numba>=0.56',
-        'numpy>=1.17',
+        'numpy>=1.18,<1.24',
         'hmmlearn>=0.2.8',
-        'dtaidistance[numpy]>=2.2',
+        'dtaidistance>=2.3.10', # [numpy]
         'scikit-learn>=1.0',
         'joblib>=0.14',
         'pydantic<1.9',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         ]
     },
     classifiers = [
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'numpy>=1.17',
         'hmmlearn>=0.2.8',
         'dtaidistance[numpy]>=2.2',
-        'scikit-learn>=0.22',
+        'scikit-learn>=1.0',
         'joblib>=0.14',
         'pydantic<1.9',
     ],


### PR DESCRIPTION
#### Major changes

- Set `max_nbytes=None` to fix read-only buffer source array error in `joblib.Parallel` (see https://github.com/scikit-learn/scikit-learn/issues/7981). ([#235](https://github.com/eonu/sequentia/pull/235))
- Added `sequentia.preprocessing` module with [`sklearn.preprocessing`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing) compatibility. ([#234](https://github.com/eonu/sequentia/pull/234))
- Added `sequentia.pipeline` module for [`sklearn.pipeline`](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.pipeline) compatibility. ([#234](https://github.com/eonu/sequentia/pull/234))

#### Minor changes

- Upgrade `sklearn` version specifier from `>=0.22` to `>=1.0`. ([#234](https://github.com/eonu/sequentia/pull/234))
- Upgrade development status classifier to stable. ([#233](https://github.com/eonu/sequentia/pull/233))