### PR TITLE
fix: use log probs for `KNNClassifier.predict_log_proba`

### DIFF
--- a/sequentia/models/knn/classifier.py
+++ b/sequentia/models/knn/classifier.py
@@ -297,7 +297,7 @@ class KNNClassifier(KNNMixin, ClassifierMixin):
         -----
         This method requires a trained classifier — see :func:`fit`.
         """
-        return np.log(self.predict_scores(X, lengths=lengths))
+        return np.log(self.predict_proba(X, lengths=lengths))
 
     @_validation.requires_fit
     def predict_proba(


### PR DESCRIPTION
## Description

Was incorrectly using `np.log(self.predict_scores(...))` instead of `np.log(self.predict_probs(...))`.

Fixes #246.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
