### PR TITLE
feat: add model spec support to `HMMClassifier.__init__`

### DIFF
--- a/docs/source/sections/model_selection/searching.rst
+++ b/docs/source/sections/model_selection/searching.rst
@@ -15,11 +15,12 @@ versions of these methods to support sequence data.
 API reference
 -------------
 
-Classes
-^^^^^^^
+Classes/Methods
+^^^^^^^^^^^^^^^
 
 .. autosummary::
 
+   ~sequentia.model_selection.param_grid
    ~sequentia.model_selection.GridSearchCV
    ~sequentia.model_selection.RandomizedSearchCV
    ~sequentia.model_selection.HalvingGridSearchCV
@@ -80,6 +81,8 @@ cross-validate a :class:`.KNNClassifier` training pipeline. ::
 
 Definitions
 ^^^^^^^^^^^
+
+.. autofunction:: sequentia.model_selection.param_grid
 
 .. autoclass:: sequentia.model_selection.GridSearchCV
    :members: __init__

--- a/sequentia/model_selection/__init__.py
+++ b/sequentia/model_selection/__init__.py
@@ -5,7 +5,11 @@
 
 """Hyper-parameter search and dataset splitting utilities."""
 
-from sequentia.model_selection._search import GridSearchCV, RandomizedSearchCV
+from sequentia.model_selection._search import (
+    GridSearchCV,
+    RandomizedSearchCV,
+    param_grid,
+)
 from sequentia.model_selection._search_successive_halving import (
     HalvingGridSearchCV,
     HalvingRandomSearchCV,
@@ -30,4 +34,5 @@ __all__ = [
     "RandomizedSearchCV",
     "HalvingGridSearchCV",
     "HalvingRandomSearchCV",
+    "param_grid",
 ]

--- a/sequentia/models/hmm/variants/__init__.py
+++ b/sequentia/models/hmm/variants/__init__.py
@@ -5,7 +5,8 @@
 
 """Supported hidden Markov Model variants."""
 
+from sequentia.models.hmm.variants.base import BaseHMM
 from sequentia.models.hmm.variants.categorical import CategoricalHMM
 from sequentia.models.hmm.variants.gaussian_mixture import GaussianMixtureHMM
 
-__all__ = ["CategoricalHMM", "GaussianMixtureHMM"]
+__all__ = ["BaseHMM", "CategoricalHMM", "GaussianMixtureHMM"]

--- a/tests/unit/test_models/hmm/test_classifier.py
+++ b/tests/unit/test_models/hmm/test_classifier.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import copy
+import enum
 import os
 import tempfile
 import typing as t
@@ -35,6 +36,12 @@ from .variants.test_gaussian_mixture import (
 )
 
 n_classes = 7
+
+
+class FitMode(enum.StrEnum):
+    PREFIT = "prefit"
+    POSTFIT_IDENTICAL = "postfit_identical"
+    POSTFIT_FLEXIBLE = "postfit_flexible"
 
 
 @pytest.fixture(scope="module")
@@ -113,16 +120,15 @@ def assert_fit(clf: BaseHMM):
         },
     ],
 )
-@pytest.mark.parametrize("prefit", [True, False])
+@pytest.mark.parametrize("fit_mode", list(FitMode))
 def test_classifier_e2e(
     request: SubRequest,
     helpers: t.Any,
     model: BaseHMM,
     dataset: SequentialDataset,
     prior: enums.PriorMode | dict[int, float],
+    fit_mode: FitMode,
     random_state: np.random.RandomState,
-    *,
-    prefit: bool,
 ) -> None:
     clf = HMMClassifier(prior=prior)
     clf.add_models({i: copy.deepcopy(model) for i in range(n_classes)})
@@ -139,12 +145,19 @@ def test_classifier_e2e(
         test_size=0.2, random_state=random_state, stratify=True
     )
 
-    if prefit:
+    if fit_mode == FitMode.PREFIT:
         for X, lengths, c in train.iter_by_class():
             clf.models[c].fit(X, lengths=lengths)
         assert_fit(clf.fit())
-    else:
+    elif fit_mode == FitMode.POSTFIT_FLEXIBLE:
         assert_fit(clf.fit(**train.X_y_lengths))
+    elif fit_mode == FitMode.POSTFIT_IDENTICAL:
+        clf = HMMClassifier(
+            variant=type(model),
+            model_kwargs=model.get_params(),
+            prior=prior,
+        )
+        clf.fit(**train.X_y_lengths)
 
     scores_pred = clf.predict_scores(**test.X_lengths)
     assert scores_pred.shape == (len(test), n_classes)


### PR DESCRIPTION
## Add model spec support to `HMMClassifier.__init__`

- Adds the ability to specify a HMM variant and configuration in `HMMClassifier.__init__`.
- This enables the use of `sequentia.model_selection` on `HMMClassifier` objects.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
