### PR TITLE
feat: add `HMMClassifier.fit` multiprocessing

### DIFF
--- a/docs/source/sections/models/index.rst
+++ b/docs/source/sections/models/index.rst
@@ -16,9 +16,9 @@ The following models provided by Sequentia all support variable length sequences
 |                                                        |                |               |              +----------+------------+
 |                                                        |                |               |              | Training | Prediction |
 +=========================+==============================+================+===============+==============+==========+============+
-| :class:`.HMMClassifier` | :class:`.GaussianMixtureHMM` | Classification | Real          | ✔            | ✗        | ✔          |
+| :class:`.HMMClassifier` | :class:`.GaussianMixtureHMM` | Classification | Real          | ✔            | ✔        | ✔          |
 |                         +------------------------------+----------------+---------------+--------------+----------+------------+
-|                         | :class:`.CategoricalHMM`     | Classification | Categorical   | ✗            | ✗        | ✔          |
+|                         | :class:`.CategoricalHMM`     | Classification | Categorical   | ✗            | ✔        | ✔          |
 +-------------------------+------------------------------+----------------+---------------+--------------+----------+------------+
 | :class:`.KNNRegressor`                                 | Regression     | Real          | ✔            | N/A      | ✔          |
 +--------------------------------------------------------+----------------+---------------+--------------+----------+------------+

--- a/sequentia/model_selection/_search.py
+++ b/sequentia/model_selection/_search.py
@@ -79,9 +79,10 @@ def param_grid(**kwargs: list[t.Any]) -> list[dict[str, t.Any]]:
     settings for :class:`.GaussianMixtureHMM`, which is a nested model
     specified in the constructor of a :class:`.HMMClassifier`. ::
 
-        from sklearn.preprocessing import Pipeline, minmax_scale
+        from sklearn.pipeline import Pipeline
+        from sklearn.preprocessing import minmax_scale
 
-        from sequenta.enums import PriorMode, CovarianceMode, TopologyMode
+        from sequentia.enums import PriorMode, CovarianceMode, TopologyMode
         from sequentia.models import HMMClassifier, GaussianMixtureHMM
         from sequentia.preprocessing import IndependentFunctionTransformer
         from sequentia.model_selection import GridSearchCV, StratifiedKFold

--- a/tests/unit/test_models/hmm/test_classifier.py
+++ b/tests/unit/test_models/hmm/test_classifier.py
@@ -121,6 +121,7 @@ def assert_fit(clf: BaseHMM):
     ],
 )
 @pytest.mark.parametrize("fit_mode", list(FitMode))
+@pytest.mark.parametrize("n_jobs", [1, -1])
 def test_classifier_e2e(
     request: SubRequest,
     helpers: t.Any,
@@ -128,9 +129,10 @@ def test_classifier_e2e(
     dataset: SequentialDataset,
     prior: enums.PriorMode | dict[int, float],
     fit_mode: FitMode,
+    n_jobs: int,
     random_state: np.random.RandomState,
 ) -> None:
-    clf = HMMClassifier(prior=prior)
+    clf = HMMClassifier(prior=prior, n_jobs=n_jobs)
     clf.add_models({i: copy.deepcopy(model) for i in range(n_classes)})
 
     assert clf.prior == prior
@@ -156,6 +158,7 @@ def test_classifier_e2e(
             variant=type(model),
             model_kwargs=model.get_params(),
             prior=prior,
+            n_jobs=n_jobs,
         )
         clf.fit(**train.X_y_lengths)
 


### PR DESCRIPTION
# Add `HMMClassifier.fit` multiprocessing

Enables multiprocessed fitting for `HMMClassifier` if not providing pre-fitted HMMs.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
