### PR TITLE
fix: enable `joblib.Parallel` memory mapping

### DIFF
--- a/benchmarks/test_pyts.py
+++ b/benchmarks/test_pyts.py
@@ -34,9 +34,7 @@ def prepare(data: SequentialDataset, length: int) -> DataSplit:
     return X_pad[:, 0], data.y
 
 
-def multivariate(
-    *, train_data: DataSplit, test_data: DataSplit, n_jobs: int
-) -> None:
+def run(*, train_data: DataSplit, test_data: DataSplit, n_jobs: int) -> None:
     """Fit and predict the classifier."""
     # initialize model
     clf = KNeighborsClassifier(
@@ -70,7 +68,7 @@ if __name__ == "__main__":
     )
 
     benchmark = timeit.timeit(
-        "func(train_data=train_data, test_data=test_data, n_jobs=args.n_jobs)",
+        "run(train_data=train_data, test_data=test_data, n_jobs=args.n_jobs)",
         globals=locals(),
         number=args.number,
     )

--- a/benchmarks/test_sequentia.py
+++ b/benchmarks/test_sequentia.py
@@ -21,7 +21,7 @@ np.random.seed(0)
 random_state: np.random.RandomState = np.random.RandomState(0)
 
 
-def multivariate(
+def run(
     *, train_data: SequentialDataset, test_data: SequentialDataset, n_jobs: int
 ) -> None:
     """Fit and predict the classifier."""
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     train_data, test_data = load_dataset(multivariate=False)
 
     benchmark = timeit.timeit(
-        "func(train_data=train_data, test_data=test_data, n_jobs=args.n_jobs)",
+        "run(train_data=train_data, test_data=test_data, n_jobs=args.n_jobs)",
         globals=locals(),
         number=args.number,
     )

--- a/benchmarks/test_sktime.py
+++ b/benchmarks/test_sktime.py
@@ -56,9 +56,7 @@ def prepare(data: SequentialDataset) -> DataSplit:
     return X_pd, data.y
 
 
-def multivariate(
-    *, train_data: DataSplit, test_data: DataSplit, n_jobs: int
-) -> None:
+def run(*, train_data: DataSplit, test_data: DataSplit, n_jobs: int) -> None:
     """Fit and predict the classifier."""
     # initialize model
     clf = KNeighborsTimeSeriesClassifier(
@@ -89,7 +87,7 @@ if __name__ == "__main__":
     train_data, test_data = prepare(train_data), prepare(test_data)
 
     benchmark = timeit.timeit(
-        "func(train_data=train_data, test_data=test_data, n_jobs=args.n_jobs)",
+        "run(train_data=train_data, test_data=test_data, n_jobs=args.n_jobs)",
         globals=locals(),
         number=args.number,
     )

--- a/sequentia/models/hmm/classifier.py
+++ b/sequentia/models/hmm/classifier.py
@@ -366,7 +366,7 @@ class HMMClassifier(ClassifierMixin):
             self.models = dict(
                 zip(
                     self.classes_,
-                    joblib.Parallel(n_jobs=n_jobs, max_nbytes=None)(
+                    joblib.Parallel(n_jobs=n_jobs, mmap_mode="r+")(
                         joblib.delayed(self.models[c].fit)(
                             X_c, lengths=lengths_c
                         )
@@ -537,7 +537,7 @@ class HMMClassifier(ClassifierMixin):
         n_jobs = _multiprocessing.effective_n_jobs(self.n_jobs, x=lengths)
         chunk_idxs = np.array_split(_data.get_idxs(lengths), n_jobs)
         return np.concatenate(
-            joblib.Parallel(n_jobs=n_jobs, max_nbytes=None)(
+            joblib.Parallel(n_jobs=n_jobs, mmap_mode="r+")(
                 joblib.delayed(self._compute_scores_chunk)(X, idxs=idxs)
                 for idxs in chunk_idxs
             )

--- a/sequentia/models/knn/base.py
+++ b/sequentia/models/knn/base.py
@@ -143,7 +143,7 @@ class KNNMixin:
 
         # multiprocessed DTW calculation
         return np.vstack(
-            joblib.Parallel(n_jobs=n_jobs, max_nbytes=None)(
+            joblib.Parallel(n_jobs=n_jobs, mmap_mode="r+")(
                 joblib.delayed(self._distance_matrix_row_chunk)(
                     row_idxs, col_chunk_idxs, X, n_jobs, dtw
                 )
@@ -245,7 +245,7 @@ class KNNMixin:
         columns.
         """
         return np.hstack(
-            joblib.Parallel(n_jobs=n_jobs, max_nbytes=None)(
+            joblib.Parallel(n_jobs=n_jobs, mmap_mode="r+")(
                 joblib.delayed(self._distance_matrix_row_col_chunk)(
                     col_idxs, row_idxs, X, dtw
                 )

--- a/sequentia/models/knn/classifier.py
+++ b/sequentia/models/knn/classifier.py
@@ -398,7 +398,7 @@ class KNNClassifier(KNNMixin, ClassifierMixin):
         n_jobs = _multiprocessing.effective_n_jobs(self.n_jobs, x=scores)
         score_chunks = np.array_split(scores, n_jobs)
         return np.concatenate(
-            joblib.Parallel(n_jobs=n_jobs, max_nbytes=None)(
+            joblib.Parallel(n_jobs=n_jobs, mmap_mode="r+")(
                 joblib.delayed(self._find_max_labels_chunk)(score_chunk)
                 for score_chunk in score_chunks
             )


### PR DESCRIPTION
## Enable `joblib.Parallel` memory mapping

- Enable memmapping by removing `max_nbytes=None`.
- Change `mmap_mode="r"` to `mmap_mode="r+"` to fix buffer error.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.