### PR TITLE
feat: set `use_c=True` by default for `KNNClassifier`/`KNNRegressor`

### DIFF
--- a/sequentia/models/knn/classifier.py
+++ b/sequentia/models/knn/classifier.py
@@ -65,7 +65,7 @@ class KNNClassifier(KNNMixin, ClassifierMixin):
         weighting: t.Callable[[FloatArray], FloatArray] | None = None,
         window: pyd.confloat(ge=0.0, le=1.0) = 1.0,
         independent: bool = False,
-        use_c: bool = False,
+        use_c: bool = True,
         n_jobs: pyd.PositiveInt | pyd.NegativeInt = 1,
         random_state: pyd.NonNegativeInt | np.random.RandomState | None = None,
         classes: list[int] | None = None,

--- a/sequentia/models/knn/regressor.py
+++ b/sequentia/models/knn/regressor.py
@@ -39,7 +39,7 @@ class KNNRegressor(KNNMixin, RegressorMixin):
         weighting: t.Callable[[FloatArray], FloatArray] | None = None,
         window: pyd.confloat(ge=0.0, le=1.0) = 1.0,
         independent: bool = False,
-        use_c: bool = False,
+        use_c: bool = True,
         n_jobs: pyd.PositiveInt | pyd.NegativeInt = 1,
         random_state: pyd.NonNegativeInt | np.random.RandomState | None = None,
     ) -> pyd.SkipValidation:


### PR DESCRIPTION
## Description

Set `use_c=True` by default for `KNNClassifier`/`KNNRegressor`.

## Checklist

- [x] I have added new tests (if necessary).
- [x] I have ensured that tests and coverage are passing on CI.
- [x] I have updated any relevant documentation (if necessary).
- [x] I have used a descriptive pull request title.
